### PR TITLE
Strip expression ops for enums

### DIFF
--- a/librlox/src/parser/expression/mod.rs
+++ b/librlox/src/parser/expression/mod.rs
@@ -321,52 +321,7 @@ impl fmt::Display for AdditionExpr {
     }
 }
 
-#[derive(Debug, PartialEq, Copy, Clone)]
-pub enum MultiplicationExprOperator {
-    Multiply,
-    Divide,
-}
-
-impl MultiplicationExprOperator {
-    pub fn from_token(token: tokens::Token) -> Result<MultiplicationExprOperator, String> {
-        match token.token_type {
-            tokens::TokenType::Star => Ok(MultiplicationExprOperator::Multiply),
-            tokens::TokenType::Slash => Ok(MultiplicationExprOperator::Divide),
-            _ => Err(format!(
-                "Unable to convert from {} to MultiplicationExprOperator",
-                token.token_type
-            )),
-        }
-    }
-}
-
-impl fmt::Display for MultiplicationExprOperator {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            MultiplicationExprOperator::Multiply => write!(f, "*"),
-            MultiplicationExprOperator::Divide => write!(f, "/"),
-        }
-    }
-}
-
-// Implement <MultiplicationExprOperator> == <tokens::Token>  comparisons
-impl PartialEq<tokens::Token> for MultiplicationExprOperator {
-    fn eq(&self, token: &tokens::Token) -> bool {
-        match self {
-            MultiplicationExprOperator::Multiply => match token.token_type {
-                tokens::TokenType::Star => true,
-                _ => false,
-            },
-            MultiplicationExprOperator::Divide => match token.token_type {
-                tokens::TokenType::Slash => true,
-                _ => false,
-            },
-        }
-    }
-}
-
-/// Represents Multiplication Lox expressions and stores an operation, along
-/// with Boxed left and right hand expressions.
+/// Represents Multiplication Lox expressions
 ///
 /// # Examples
 /// ```
@@ -374,11 +329,9 @@ impl PartialEq<tokens::Token> for MultiplicationExprOperator {
 /// use librlox::scanner::tokens::{Literal, TokenType, Token};
 /// use librlox::parser::expression::*;
 /// use std::option::Option::Some;
-/// use std::convert::TryFrom;
 ///
 /// let multiplication = Expr::Multiplication(
-///     MultiplicationExpr::new(
-///         MultiplicationExprOperator::Multiply,
+///     MultiplicationExpr::Multiply(
 ///         Box::new(
 ///             Expr::Primary(
 ///                 PrimaryExpr::Number(5.0)
@@ -393,29 +346,17 @@ impl PartialEq<tokens::Token> for MultiplicationExprOperator {
 /// );
 /// ```
 #[derive(Debug, PartialEq)]
-pub struct MultiplicationExpr {
-    operation: MultiplicationExprOperator,
-    lhe: Box<Expr>,
-    rhe: Box<Expr>,
-}
-
-impl MultiplicationExpr {
-    pub fn new(
-        op: MultiplicationExprOperator,
-        lhe: Box<Expr>,
-        rhe: Box<Expr>,
-    ) -> MultiplicationExpr {
-        MultiplicationExpr {
-            operation: op,
-            lhe,
-            rhe,
-        }
-    }
+pub enum MultiplicationExpr {
+    Multiply(Box<Expr>, Box<Expr>),
+    Divide(Box<Expr>, Box<Expr>),
 }
 
 impl fmt::Display for MultiplicationExpr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "({} {} {})", self.operation, self.lhe, self.rhe)
+        match self {
+            MultiplicationExpr::Multiply(left, right) => write!(f, "(* {} {})", left, right),
+            MultiplicationExpr::Divide(left, right) => write!(f, "(/ {} {})", left, right),
+        }
     }
 }
 

--- a/librlox/src/parser/expression/mod.rs
+++ b/librlox/src/parser/expression/mod.rs
@@ -121,66 +121,7 @@ impl fmt::Display for EqualityExpr {
     }
 }
 
-#[derive(Debug, PartialEq, Copy, Clone)]
-pub enum ComparisonExprOperator {
-    Greater,
-    GreaterEqual,
-    Less,
-    LessEqual,
-}
-
-impl ComparisonExprOperator {
-    pub fn from_token(token: tokens::Token) -> Result<ComparisonExprOperator, String> {
-        match token.token_type {
-            tokens::TokenType::Greater => Ok(ComparisonExprOperator::Greater),
-            tokens::TokenType::GreaterEqual => Ok(ComparisonExprOperator::GreaterEqual),
-            tokens::TokenType::Less => Ok(ComparisonExprOperator::Less),
-            tokens::TokenType::LessEqual => Ok(ComparisonExprOperator::LessEqual),
-            _ => Err(format!(
-                "Unable to convert from {} to ComparisonExprOperator",
-                token.token_type
-            )),
-        }
-    }
-}
-
-impl fmt::Display for ComparisonExprOperator {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ComparisonExprOperator::Greater => write!(f, ">"),
-            ComparisonExprOperator::GreaterEqual => write!(f, ">="),
-            ComparisonExprOperator::Less => write!(f, "<"),
-            ComparisonExprOperator::LessEqual => write!(f, "<="),
-        }
-    }
-}
-
-// Implement <ComparisonExprOperator> == <tokens::Token>  comparisons
-impl PartialEq<tokens::Token> for ComparisonExprOperator {
-    fn eq(&self, token: &tokens::Token) -> bool {
-        match self {
-            ComparisonExprOperator::Greater => match token.token_type {
-                tokens::TokenType::Greater => true,
-                _ => false,
-            },
-            ComparisonExprOperator::GreaterEqual => match token.token_type {
-                tokens::TokenType::GreaterEqual => true,
-                _ => false,
-            },
-            ComparisonExprOperator::Less => match token.token_type {
-                tokens::TokenType::Less => true,
-                _ => false,
-            },
-            ComparisonExprOperator::LessEqual => match token.token_type {
-                tokens::TokenType::LessEqual => true,
-                _ => false,
-            },
-        }
-    }
-}
-
-/// Represents Comparison Lox expressions and stores an operation, along
-/// with Boxed left and right hand expressions.
+/// Represents Comparison Lox expressions.
 ///
 /// # Examples
 /// ```
@@ -190,8 +131,7 @@ impl PartialEq<tokens::Token> for ComparisonExprOperator {
 /// use std::option::Option::Some;
 ///
 /// let comparison = Expr::Comparison(
-///     ComparisonExpr::new(
-///         ComparisonExprOperator::GreaterEqual,
+///     ComparisonExpr::GreaterEqual(
 ///         Box::new(
 ///             Expr::Primary(
 ///                 PrimaryExpr::Number(5.0)
@@ -206,25 +146,21 @@ impl PartialEq<tokens::Token> for ComparisonExprOperator {
 /// );
 /// ```
 #[derive(Debug, PartialEq)]
-pub struct ComparisonExpr {
-    operation: ComparisonExprOperator,
-    lhe: Box<Expr>,
-    rhe: Box<Expr>,
-}
-
-impl ComparisonExpr {
-    pub fn new(op: ComparisonExprOperator, lhe: Box<Expr>, rhe: Box<Expr>) -> ComparisonExpr {
-        ComparisonExpr {
-            operation: op,
-            lhe,
-            rhe,
-        }
-    }
+pub enum ComparisonExpr {
+    Less(Box<Expr>, Box<Expr>),
+    LessEqual(Box<Expr>, Box<Expr>),
+    Greater(Box<Expr>, Box<Expr>),
+    GreaterEqual(Box<Expr>, Box<Expr>),
 }
 
 impl fmt::Display for ComparisonExpr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "({} {} {})", self.operation, self.lhe, self.rhe)
+        match self {
+            ComparisonExpr::Less(left, right) => write!(f, "(< {} {})", left, right),
+            ComparisonExpr::LessEqual(left, right) => write!(f, "(<= {} {})", left, right),
+            ComparisonExpr::Greater(left, right) => write!(f, "(> {} {})", left, right),
+            ComparisonExpr::GreaterEqual(left, right) => write!(f, "(>= {} {})", left, right),
+        }
     }
 }
 

--- a/librlox/src/parser/expression/mod.rs
+++ b/librlox/src/parser/expression/mod.rs
@@ -370,13 +370,11 @@ impl std::convert::TryFrom<tokens::Token> for PrimaryExpr {
             (tokens::TokenType::True, None) => Ok(PrimaryExpr::True),
             (tokens::TokenType::False, None) => Ok(PrimaryExpr::False),
             (tokens::TokenType::Literal, Some(tokens::Literal::Identifier(v))) => {
-                Ok(PrimaryExpr::Identifier(v.clone()))
+                Ok(PrimaryExpr::Identifier(v))
             }
-            (tokens::TokenType::Literal, Some(tokens::Literal::Str(v))) => {
-                Ok(PrimaryExpr::Str(v.clone()))
-            }
+            (tokens::TokenType::Literal, Some(tokens::Literal::Str(v))) => Ok(PrimaryExpr::Str(v)),
             (tokens::TokenType::Literal, Some(tokens::Literal::Number(v))) => {
-                Ok(PrimaryExpr::Number(v.clone()))
+                Ok(PrimaryExpr::Number(v))
             }
             // Placeholder
             _ => Err(format!("invalid token: {}", t.token_type)),

--- a/librlox/src/parser/expression/mod.rs
+++ b/librlox/src/parser/expression/mod.rs
@@ -28,52 +28,7 @@ impl fmt::Display for Expr {
     }
 }
 
-#[derive(Debug, PartialEq, Copy, Clone)]
-pub enum EqualityExprOperator {
-    Equal,
-    NotEqual,
-}
-
-impl EqualityExprOperator {
-    pub fn from_token(token: tokens::Token) -> Result<EqualityExprOperator, String> {
-        match token.token_type {
-            tokens::TokenType::EqualEqual => Ok(EqualityExprOperator::Equal),
-            tokens::TokenType::BangEqual => Ok(EqualityExprOperator::NotEqual),
-            _ => Err(format!(
-                "Unable to convert from {} to EqualityExprOperator",
-                token.token_type
-            )),
-        }
-    }
-}
-
-impl fmt::Display for EqualityExprOperator {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            EqualityExprOperator::Equal => write!(f, "=="),
-            EqualityExprOperator::NotEqual => write!(f, "!="),
-        }
-    }
-}
-
-// Implement <EqualityExprOperator> == <tokens::Token>  comparisons
-impl PartialEq<tokens::Token> for EqualityExprOperator {
-    fn eq(&self, token: &tokens::Token) -> bool {
-        match self {
-            EqualityExprOperator::Equal => match token.token_type {
-                tokens::TokenType::EqualEqual => true,
-                _ => false,
-            },
-            EqualityExprOperator::NotEqual => match token.token_type {
-                tokens::TokenType::BangEqual => true,
-                _ => false,
-            },
-        }
-    }
-}
-
-/// Represents Equality Lox expressions and stores an operation, along
-/// with Boxed left and right hand expressions.
+/// Represents Equality Lox expressions.
 ///
 /// # Examples
 /// ```
@@ -83,8 +38,7 @@ impl PartialEq<tokens::Token> for EqualityExprOperator {
 /// use std::option::Option::Some;
 ///
 /// let comparison = Expr::Equality(
-///     EqualityExpr::new(
-///         EqualityExprOperator::NotEqual,
+///     EqualityExpr::NotEqual(
 ///         Box::new(
 ///             Expr::Primary(
 ///                 PrimaryExpr::Number(5.0)
@@ -99,25 +53,17 @@ impl PartialEq<tokens::Token> for EqualityExprOperator {
 /// );
 /// ```
 #[derive(Debug, PartialEq)]
-pub struct EqualityExpr {
-    operation: EqualityExprOperator,
-    lhe: Box<Expr>,
-    rhe: Box<Expr>,
-}
-
-impl EqualityExpr {
-    pub fn new(op: EqualityExprOperator, lhe: Box<Expr>, rhe: Box<Expr>) -> EqualityExpr {
-        EqualityExpr {
-            operation: op,
-            lhe,
-            rhe,
-        }
-    }
+pub enum EqualityExpr {
+    Equal(Box<Expr>, Box<Expr>),
+    NotEqual(Box<Expr>, Box<Expr>),
 }
 
 impl fmt::Display for EqualityExpr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "({} {} {})", self.operation, self.lhe, self.rhe)
+        match self {
+            EqualityExpr::Equal(left, right) => write!(f, "(== {} {})", left, right),
+            EqualityExpr::NotEqual(left, right) => write!(f, "(!= {} {})", left, right),
+        }
     }
 }
 

--- a/librlox/src/parser/expression/mod.rs
+++ b/librlox/src/parser/expression/mod.rs
@@ -228,52 +228,7 @@ impl fmt::Display for ComparisonExpr {
     }
 }
 
-#[derive(Debug, PartialEq, Copy, Clone)]
-pub enum AdditionExprOperator {
-    Addition,
-    Subraction,
-}
-
-impl AdditionExprOperator {
-    pub fn from_token(token: tokens::Token) -> Result<AdditionExprOperator, String> {
-        match token.token_type {
-            tokens::TokenType::Plus => Ok(AdditionExprOperator::Addition),
-            tokens::TokenType::Minus => Ok(AdditionExprOperator::Subraction),
-            _ => Err(format!(
-                "Unable to convert from {} to AdditionExprOperator",
-                token.token_type
-            )),
-        }
-    }
-}
-
-impl fmt::Display for AdditionExprOperator {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            AdditionExprOperator::Addition => write!(f, "+"),
-            AdditionExprOperator::Subraction => write!(f, "-"),
-        }
-    }
-}
-
-// Implement <AdditionExprOperator> == <tokens::Token>  comparisons
-impl PartialEq<tokens::Token> for AdditionExprOperator {
-    fn eq(&self, token: &tokens::Token) -> bool {
-        match self {
-            AdditionExprOperator::Addition => match token.token_type {
-                tokens::TokenType::Plus => true,
-                _ => false,
-            },
-            AdditionExprOperator::Subraction => match token.token_type {
-                tokens::TokenType::Minus => true,
-                _ => false,
-            },
-        }
-    }
-}
-
-/// Represents Addition Lox expressions and stores an operation, along
-/// with Boxed left and right hand expressions.
+/// Represents Addition Lox expressions.
 ///
 /// # Examples
 /// ```
@@ -283,8 +238,7 @@ impl PartialEq<tokens::Token> for AdditionExprOperator {
 /// use std::option::Option::Some;
 ///
 /// let addition = Expr::Addition(
-///     AdditionExpr::new(
-///         AdditionExprOperator::Addition,
+///     AdditionExpr::Add(
 ///         Box::new(
 ///             Expr::Primary(
 ///                 PrimaryExpr::Number(5.0)
@@ -299,29 +253,21 @@ impl PartialEq<tokens::Token> for AdditionExprOperator {
 /// );
 /// ```
 #[derive(Debug, PartialEq)]
-pub struct AdditionExpr {
-    operation: AdditionExprOperator,
-    lhe: Box<Expr>,
-    rhe: Box<Expr>,
-}
-
-impl AdditionExpr {
-    pub fn new(op: AdditionExprOperator, lhe: Box<Expr>, rhe: Box<Expr>) -> AdditionExpr {
-        AdditionExpr {
-            operation: op,
-            lhe,
-            rhe,
-        }
-    }
+pub enum AdditionExpr {
+    Add(Box<Expr>, Box<Expr>),
+    Subtract(Box<Expr>, Box<Expr>),
 }
 
 impl fmt::Display for AdditionExpr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "({} {} {})", self.operation, self.lhe, self.rhe)
+        match self {
+            AdditionExpr::Add(left, right) => write!(f, "(+ {} {})", left, right),
+            AdditionExpr::Subtract(left, right) => write!(f, "(- {} {})", left, right),
+        }
     }
 }
 
-/// Represents Multiplication Lox expressions
+/// Represents Multiplication Lox expressions.
 ///
 /// # Examples
 /// ```
@@ -360,7 +306,7 @@ impl fmt::Display for MultiplicationExpr {
     }
 }
 
-/// Represents a unary Lox expressions
+/// Represents a unary Lox expressions.
 ///
 /// # Examples
 /// ```

--- a/librlox/src/parser/expression/mod.rs
+++ b/librlox/src/parser/expression/mod.rs
@@ -419,52 +419,7 @@ impl fmt::Display for MultiplicationExpr {
     }
 }
 
-#[derive(Debug, PartialEq, Copy, Clone)]
-pub enum UnaryExprOperator {
-    Bang,
-    Minus,
-}
-
-impl UnaryExprOperator {
-    pub fn from_token(token: tokens::Token) -> Result<UnaryExprOperator, String> {
-        match token.token_type {
-            tokens::TokenType::Bang => Ok(UnaryExprOperator::Bang),
-            tokens::TokenType::Minus => Ok(UnaryExprOperator::Minus),
-            _ => Err(format!(
-                "Unable to convert from {} to UnaryExprOperator",
-                token.token_type
-            )),
-        }
-    }
-}
-
-impl fmt::Display for UnaryExprOperator {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            UnaryExprOperator::Bang => write!(f, "!"),
-            UnaryExprOperator::Minus => write!(f, "-"),
-        }
-    }
-}
-
-// Implement <UnaryExprOperator> == <tokens::Token>  comparisons
-impl PartialEq<tokens::Token> for UnaryExprOperator {
-    fn eq(&self, token: &tokens::Token) -> bool {
-        match self {
-            UnaryExprOperator::Bang => match token.token_type {
-                tokens::TokenType::Bang => true,
-                _ => false,
-            },
-            UnaryExprOperator::Minus => match token.token_type {
-                tokens::TokenType::Minus => true,
-                _ => false,
-            },
-        }
-    }
-}
-
-/// Represents Unary Lox expressions and stores an operation token, along with
-/// a single, right hand, expression.
+/// Represents a unary Lox expressions
 ///
 /// # Examples
 /// ```
@@ -474,31 +429,27 @@ impl PartialEq<tokens::Token> for UnaryExprOperator {
 /// use std::option::Option::Some;
 ///
 /// let unary = Expr::Unary(
-///     UnaryExpr::new(
-///         UnaryExprOperator::Minus,
+///     UnaryExpr::Minus(
 ///         Box::new(
 ///             Expr::Primary(
 ///                 PrimaryExpr::Number(5.0)
 ///             )
-///         ),
+///         )
 ///     )
 /// );
 /// ```
 #[derive(Debug, PartialEq)]
-pub struct UnaryExpr {
-    operation: UnaryExprOperator,
-    rhe: Box<Expr>,
-}
-
-impl UnaryExpr {
-    pub fn new(operation: UnaryExprOperator, rhe: Box<Expr>) -> UnaryExpr {
-        UnaryExpr { operation, rhe }
-    }
+pub enum UnaryExpr {
+    Bang(Box<Expr>),
+    Minus(Box<Expr>),
 }
 
 impl fmt::Display for UnaryExpr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "({} {})", self.operation, self.rhe)
+        match self {
+            UnaryExpr::Bang(expr) => write!(f, "(! {})", expr),
+            UnaryExpr::Minus(expr) => write!(f, "(- {})", expr),
+        }
     }
 }
 

--- a/librlox/src/parser/expression_parser.rs
+++ b/librlox/src/parser/expression_parser.rs
@@ -219,10 +219,11 @@ fn unary<'a>() -> impl parcel::Parser<'a, &'a [Token], Expr> {
         primary(),
     )
     .map(|(token, lit)| {
-        Expr::Unary(UnaryExpr::new(
-            UnaryExprOperator::from_token(token).unwrap(),
-            Box::new(lit),
-        ))
+        Expr::Unary(match token.token_type {
+            TokenType::Minus => UnaryExpr::Minus(Box::new(lit)),
+            TokenType::Bang => UnaryExpr::Bang(Box::new(lit)),
+            _ => panic!(format!("unexpected token: {}", token.token_type)),
+        })
     })
     .or(|| primary())
 }

--- a/librlox/src/parser/expression_parser.rs
+++ b/librlox/src/parser/expression_parser.rs
@@ -135,11 +135,15 @@ fn comparison<'a>() -> impl parcel::Parser<'a, &'a [Token], Expr> {
         for op in operators_iter {
             // this is fairly safe due to the parser guaranteeing enough args.
             let left = operands_iter.next().unwrap();
-            last = Expr::Comparison(ComparisonExpr::new(
-                ComparisonExprOperator::from_token(op).unwrap(),
-                Box::new(left),
-                Box::new(last),
-            ))
+            last = Expr::Comparison(match op.token_type {
+                TokenType::Less => ComparisonExpr::Less(Box::new(left), Box::new(last)),
+                TokenType::LessEqual => ComparisonExpr::LessEqual(Box::new(left), Box::new(last)),
+                TokenType::Greater => ComparisonExpr::Greater(Box::new(left), Box::new(last)),
+                TokenType::GreaterEqual => {
+                    ComparisonExpr::GreaterEqual(Box::new(left), Box::new(last))
+                }
+                _ => panic!(format!("unexpected token: {}", op.token_type)),
+            })
         }
         last
     })

--- a/librlox/src/parser/expression_parser.rs
+++ b/librlox/src/parser/expression_parser.rs
@@ -201,11 +201,11 @@ fn multiplication<'a>() -> impl parcel::Parser<'a, &'a [Token], Expr> {
         for op in operators_iter {
             // this is fairly safe due to the parser guaranteeing enough args.
             let left = operands_iter.next().unwrap();
-            last = Expr::Multiplication(MultiplicationExpr::new(
-                MultiplicationExprOperator::from_token(op).unwrap(),
-                Box::new(left),
-                Box::new(last),
-            ))
+            last = Expr::Multiplication(match op.token_type {
+                TokenType::Star => MultiplicationExpr::Multiply(Box::new(left), Box::new(last)),
+                TokenType::Slash => MultiplicationExpr::Divide(Box::new(left), Box::new(last)),
+                _ => panic!(format!("unexpected token: {}", op.token_type)),
+            })
         }
         last
     })

--- a/librlox/src/parser/expression_parser.rs
+++ b/librlox/src/parser/expression_parser.rs
@@ -99,11 +99,11 @@ fn equality<'a>() -> impl parcel::Parser<'a, &'a [Token], Expr> {
         for op in operators_iter {
             // this is fairly safe due to the parser guaranteeing enough args.
             let left = operands_iter.next().unwrap();
-            last = Expr::Equality(EqualityExpr::new(
-                EqualityExprOperator::from_token(op).unwrap(),
-                Box::new(left),
-                Box::new(last),
-            ))
+            last = Expr::Equality(match op.token_type {
+                TokenType::EqualEqual => EqualityExpr::Equal(Box::new(left), Box::new(last)),
+                TokenType::BangEqual => EqualityExpr::NotEqual(Box::new(left), Box::new(last)),
+                _ => panic!(format!("unexpected token: {}", op.token_type)),
+            })
         }
         last
     })

--- a/librlox/src/parser/expression_parser.rs
+++ b/librlox/src/parser/expression_parser.rs
@@ -168,11 +168,11 @@ fn addition<'a>() -> impl parcel::Parser<'a, &'a [Token], Expr> {
         for op in operators_iter {
             // this is fairly safe due to the parser guaranteeing enough args.
             let left = operands_iter.next().unwrap();
-            last = Expr::Addition(AdditionExpr::new(
-                AdditionExprOperator::from_token(op).unwrap(),
-                Box::new(left),
-                Box::new(last),
-            ))
+            last = Expr::Addition(match op.token_type {
+                TokenType::Plus => AdditionExpr::Add(Box::new(left), Box::new(last)),
+                TokenType::Minus => AdditionExpr::Subtract(Box::new(left), Box::new(last)),
+                _ => panic!(format!("unexpected token: {}", op.token_type)),
+            })
         }
         last
     })

--- a/librlox/src/parser/tests/expression.rs
+++ b/librlox/src/parser/tests/expression.rs
@@ -1,7 +1,5 @@
 use crate::parser::expression::{Expr, GroupingExpr, PrimaryExpr, UnaryExpr};
-use crate::parser::expression::{
-    MultiplicationExpr, MultiplicationExprOperator, UnaryExprOperator,
-};
+use crate::parser::expression::{MultiplicationExpr, MultiplicationExprOperator};
 use crate::scanner::tokens::{Literal, Token, TokenType};
 use std::convert::TryFrom;
 use std::option::Option;
@@ -10,16 +8,13 @@ use std::option::Option;
 fn test_expression_formatter_should_pretty_print_an_ast() {
     let expr = Expr::Multiplication(MultiplicationExpr::new(
         MultiplicationExprOperator::Multiply,
-        Box::new(Expr::Unary(UnaryExpr::new(
-            UnaryExprOperator::Minus,
-            Box::new(Expr::Primary(
-                PrimaryExpr::try_from(Token::new(
-                    TokenType::Literal,
-                    Option::Some(Literal::Number(123.0)),
-                ))
-                .unwrap(),
-            )),
-        ))),
+        Box::new(Expr::Unary(UnaryExpr::Minus(Box::new(Expr::Primary(
+            PrimaryExpr::try_from(Token::new(
+                TokenType::Literal,
+                Option::Some(Literal::Number(123.0)),
+            ))
+            .unwrap(),
+        ))))),
         Box::new(Expr::Grouping(GroupingExpr::new(Box::new(Expr::Primary(
             PrimaryExpr::try_from(Token::new(
                 TokenType::Literal,

--- a/librlox/src/parser/tests/expression.rs
+++ b/librlox/src/parser/tests/expression.rs
@@ -1,13 +1,12 @@
+use crate::parser::expression::MultiplicationExpr;
 use crate::parser::expression::{Expr, GroupingExpr, PrimaryExpr, UnaryExpr};
-use crate::parser::expression::{MultiplicationExpr, MultiplicationExprOperator};
 use crate::scanner::tokens::{Literal, Token, TokenType};
 use std::convert::TryFrom;
 use std::option::Option;
 
 #[test]
 fn test_expression_formatter_should_pretty_print_an_ast() {
-    let expr = Expr::Multiplication(MultiplicationExpr::new(
-        MultiplicationExprOperator::Multiply,
+    let expr = Expr::Multiplication(MultiplicationExpr::Multiply(
         Box::new(Expr::Unary(UnaryExpr::Minus(Box::new(Expr::Primary(
             PrimaryExpr::try_from(Token::new(
                 TokenType::Literal,

--- a/librlox/src/parser/tests/expression_parser.rs
+++ b/librlox/src/parser/tests/expression_parser.rs
@@ -1,8 +1,7 @@
 extern crate parcel;
 use crate::parser::expression::{
     AdditionExpr, AdditionExprOperator, ComparisonExpr, ComparisonExprOperator, EqualityExpr,
-    EqualityExprOperator, Expr, GroupingExpr, MultiplicationExpr, MultiplicationExprOperator,
-    PrimaryExpr, UnaryExpr,
+    EqualityExprOperator, Expr, GroupingExpr, MultiplicationExpr, PrimaryExpr, UnaryExpr,
 };
 use crate::parser::expression_parser::expression;
 use crate::scanner::tokens::{Literal, Token, TokenType};
@@ -220,8 +219,7 @@ fn validate_parser_should_parse_multiplication_expression() {
     assert_eq!(
         Ok(MatchStatus::Match((
             &seed_vec[3..],
-            Expr::Multiplication(MultiplicationExpr::new(
-                MultiplicationExprOperator::Multiply,
+            Expr::Multiplication(MultiplicationExpr::Multiply(
                 Box::new(Expr::Primary(
                     PrimaryExpr::try_from(literal_token.clone()).unwrap()
                 )),
@@ -249,13 +247,11 @@ fn validate_parser_should_parse_many_multiplication_expression() {
     assert_eq!(
         Ok(MatchStatus::Match((
             &seed_vec[5..],
-            Expr::Multiplication(MultiplicationExpr::new(
-                MultiplicationExprOperator::Multiply,
+            Expr::Multiplication(MultiplicationExpr::Multiply(
                 Box::new(Expr::Primary(
                     PrimaryExpr::try_from(literal_token.clone()).unwrap()
                 )),
-                Box::new(Expr::Multiplication(MultiplicationExpr::new(
-                    MultiplicationExprOperator::Multiply,
+                Box::new(Expr::Multiplication(MultiplicationExpr::Multiply(
                     Box::new(Expr::Primary(
                         PrimaryExpr::try_from(literal_token.clone()).unwrap()
                     )),

--- a/librlox/src/parser/tests/expression_parser.rs
+++ b/librlox/src/parser/tests/expression_parser.rs
@@ -1,7 +1,7 @@
 extern crate parcel;
 use crate::parser::expression::{
-    AdditionExpr, AdditionExprOperator, ComparisonExpr, ComparisonExprOperator, EqualityExpr,
-    EqualityExprOperator, Expr, GroupingExpr, MultiplicationExpr, PrimaryExpr, UnaryExpr,
+    AdditionExpr, ComparisonExpr, ComparisonExprOperator, EqualityExpr, EqualityExprOperator, Expr,
+    GroupingExpr, MultiplicationExpr, PrimaryExpr, UnaryExpr,
 };
 use crate::parser::expression_parser::expression;
 use crate::scanner::tokens::{Literal, Token, TokenType};
@@ -157,8 +157,7 @@ fn validate_parser_should_parse_addition_expression() {
     assert_eq!(
         Ok(MatchStatus::Match((
             &seed_vec[3..],
-            Expr::Addition(AdditionExpr::new(
-                AdditionExprOperator::Addition,
+            Expr::Addition(AdditionExpr::Add(
                 Box::new(Expr::Primary(
                     PrimaryExpr::try_from(literal_token.clone()).unwrap()
                 )),
@@ -186,13 +185,11 @@ fn validate_parser_should_parse_many_addition_expression() {
     assert_eq!(
         Ok(MatchStatus::Match((
             &seed_vec[5..],
-            Expr::Addition(AdditionExpr::new(
-                AdditionExprOperator::Addition,
+            Expr::Addition(AdditionExpr::Add(
                 Box::new(Expr::Primary(
                     PrimaryExpr::try_from(literal_token.clone()).unwrap()
                 )),
-                Box::new(Expr::Addition(AdditionExpr::new(
-                    AdditionExprOperator::Addition,
+                Box::new(Expr::Addition(AdditionExpr::Add(
                     Box::new(Expr::Primary(
                         PrimaryExpr::try_from(literal_token.clone()).unwrap()
                     )),

--- a/librlox/src/parser/tests/expression_parser.rs
+++ b/librlox/src/parser/tests/expression_parser.rs
@@ -2,7 +2,7 @@ extern crate parcel;
 use crate::parser::expression::{
     AdditionExpr, AdditionExprOperator, ComparisonExpr, ComparisonExprOperator, EqualityExpr,
     EqualityExprOperator, Expr, GroupingExpr, MultiplicationExpr, MultiplicationExprOperator,
-    PrimaryExpr, UnaryExpr, UnaryExprOperator,
+    PrimaryExpr, UnaryExpr,
 };
 use crate::parser::expression_parser::expression;
 use crate::scanner::tokens::{Literal, Token, TokenType};
@@ -278,10 +278,9 @@ fn validate_parser_should_parse_unary_expression() {
     assert_eq!(
         Ok(MatchStatus::Match((
             &seed_vec[2..],
-            Expr::Unary(UnaryExpr::new(
-                UnaryExprOperator::Bang,
-                Box::new(Expr::Primary(PrimaryExpr::try_from(literal_token).unwrap()))
-            ))
+            Expr::Unary(UnaryExpr::Bang(Box::new(Expr::Primary(
+                PrimaryExpr::try_from(literal_token).unwrap()
+            ))))
         ))),
         expression().parse(&seed_vec)
     );

--- a/librlox/src/parser/tests/expression_parser.rs
+++ b/librlox/src/parser/tests/expression_parser.rs
@@ -1,7 +1,7 @@
 extern crate parcel;
 use crate::parser::expression::{
-    AdditionExpr, ComparisonExpr, ComparisonExprOperator, EqualityExpr, EqualityExprOperator, Expr,
-    GroupingExpr, MultiplicationExpr, PrimaryExpr, UnaryExpr,
+    AdditionExpr, ComparisonExpr, EqualityExpr, EqualityExprOperator, Expr, GroupingExpr,
+    MultiplicationExpr, PrimaryExpr, UnaryExpr,
 };
 use crate::parser::expression_parser::expression;
 use crate::scanner::tokens::{Literal, Token, TokenType};
@@ -95,8 +95,7 @@ fn validate_parser_should_parse_comparison_expression() {
     assert_eq!(
         Ok(MatchStatus::Match((
             &seed_vec[3..],
-            Expr::Comparison(ComparisonExpr::new(
-                ComparisonExprOperator::GreaterEqual,
+            Expr::Comparison(ComparisonExpr::GreaterEqual(
                 Box::new(Expr::Primary(
                     PrimaryExpr::try_from(literal_token.clone()).unwrap()
                 )),
@@ -124,13 +123,11 @@ fn validate_parser_should_parse_many_comparison_expression() {
     assert_eq!(
         Ok(MatchStatus::Match((
             &seed_vec[5..],
-            Expr::Comparison(ComparisonExpr::new(
-                ComparisonExprOperator::GreaterEqual,
+            Expr::Comparison(ComparisonExpr::GreaterEqual(
                 Box::new(Expr::Primary(
                     PrimaryExpr::try_from(literal_token.clone()).unwrap()
                 )),
-                Box::new(Expr::Comparison(ComparisonExpr::new(
-                    ComparisonExprOperator::GreaterEqual,
+                Box::new(Expr::Comparison(ComparisonExpr::GreaterEqual(
                     Box::new(Expr::Primary(
                         PrimaryExpr::try_from(literal_token.clone()).unwrap()
                     )),

--- a/librlox/src/parser/tests/expression_parser.rs
+++ b/librlox/src/parser/tests/expression_parser.rs
@@ -1,7 +1,7 @@
 extern crate parcel;
 use crate::parser::expression::{
-    AdditionExpr, ComparisonExpr, EqualityExpr, EqualityExprOperator, Expr, GroupingExpr,
-    MultiplicationExpr, PrimaryExpr, UnaryExpr,
+    AdditionExpr, ComparisonExpr, EqualityExpr, Expr, GroupingExpr, MultiplicationExpr,
+    PrimaryExpr, UnaryExpr,
 };
 use crate::parser::expression_parser::expression;
 use crate::scanner::tokens::{Literal, Token, TokenType};
@@ -33,8 +33,7 @@ fn validate_parser_should_parse_equality_expression() {
     assert_eq!(
         Ok(MatchStatus::Match((
             &seed_vec[3..],
-            Expr::Equality(EqualityExpr::new(
-                EqualityExprOperator::Equal,
+            Expr::Equality(EqualityExpr::Equal(
                 Box::new(Expr::Primary(
                     PrimaryExpr::try_from(literal_token.clone()).unwrap()
                 )),
@@ -62,13 +61,11 @@ fn validate_parser_should_parse_many_equality_expression() {
     assert_eq!(
         Ok(MatchStatus::Match((
             &seed_vec[5..],
-            Expr::Equality(EqualityExpr::new(
-                EqualityExprOperator::Equal,
+            Expr::Equality(EqualityExpr::Equal(
                 Box::new(Expr::Primary(
                     PrimaryExpr::try_from(literal_token.clone()).unwrap()
                 )),
-                Box::new(Expr::Equality(EqualityExpr::new(
-                    EqualityExprOperator::Equal,
+                Box::new(Expr::Equality(EqualityExpr::Equal(
                     Box::new(Expr::Primary(
                         PrimaryExpr::try_from(literal_token.clone()).unwrap()
                     )),


### PR DESCRIPTION
# Introduction
This PR removes the ExpressionOp struct in favor of converting the Expr structs into an Enum, capturing the operation in each variant.

# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [ ] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
