### PR TITLE
Fix bug in scanner where numbers eat next operator

### DIFF
--- a/librlox/src/scanner/source_scanner.rs
+++ b/librlox/src/scanner/source_scanner.rs
@@ -304,13 +304,11 @@ impl Scanner {
                     }
                 }
                 _ => {
-                    //reverse reader one step to negate quote
-                    let literal_str: String = self
-                        .substring(start, Cursor::reverse(current))
-                        .iter()
-                        .collect();
+                    // rewind cursor to not eat next token.
+                    let current = Cursor::reverse(current);
+                    let literal_num: String = self.substring(start, current).iter().collect();
 
-                    return match literal_str.parse() {
+                    return match literal_num.parse() {
                         Ok(n) => (
                             Ok(Token::new(TokenType::Literal, Some(Literal::Number(n)))),
                             current,

--- a/librlox/src/scanner/tests/token_lexing/numbers.rs
+++ b/librlox/src/scanner/tests/token_lexing/numbers.rs
@@ -27,9 +27,37 @@ fn scan_tokens_should_not_allow_trailing_decimal() {
     let s = Scanner::new(source);
     let token_results = s.scan_tokens();
 
-    //assert_eq!(1, token_results.len());
     assert_eq!(
         token_results[0],
         LexResult::Err("Invalid number at line: 1, position: 3".to_string())
+    );
+}
+
+#[test]
+fn scan_tokens_should_allow_numbers_to_include_operators() {
+    let source = "5+5".to_string();
+    let s = Scanner::new(source);
+    let token_results = s.scan_tokens();
+
+    assert_eq!(
+        token_results,
+        vec![
+            LexResult::Ok(Token {
+                token_type: TokenType::Literal,
+                literal: Some(Literal::Number(5.0)),
+            }),
+            LexResult::Ok(Token {
+                token_type: TokenType::Plus,
+                literal: None,
+            }),
+            LexResult::Ok(Token {
+                token_type: TokenType::Literal,
+                literal: Some(Literal::Number(5.0)),
+            }),
+            LexResult::Ok(Token {
+                token_type: TokenType::EOF,
+                literal: None,
+            })
+        ]
     );
 }


### PR DESCRIPTION
# Introduction
This PR fixes a bug in the scanner that causes numbers to eat the next token when scanning forcing all expressions to require whitespace when paired with numbers. This appeared to only affect numbers and was due to numbers not rewinding a character after lookahead.

```
> 5+5
5
> "hello"+"world"
helloworld
```

# Linked Issues
resolves #50 
# Dependencies

# Test
- [x] Tested Locally

```
> 4*(2+3)
20
> "hello"+"world"
helloworld
> 
```

- [ ] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
