### PR TITLE
Remove Identifier from runtime object and into variable expression

### DIFF
--- a/librlox/src/ast/expression.rs
+++ b/librlox/src/ast/expression.rs
@@ -13,7 +13,7 @@ pub enum Expr {
     Unary(UnaryExpr),
     Primary(PrimaryExpr),
     Grouping(Box<Expr>),
-    Variable(String),
+    Variable(token::Token),
 }
 
 impl fmt::Display for Expr {
@@ -26,7 +26,7 @@ impl fmt::Display for Expr {
             Self::Unary(e) => write!(f, "{}", &e),
             Self::Primary(e) => write!(f, "{}", &e),
             Self::Grouping(e) => write!(f, "(Grouping {})", &e),
-            Self::Variable(i) => write!(f, "(Var {})", &i),
+            Self::Variable(i) => write!(f, "(Var {})", &i.lexeme.clone().unwrap()),
         }
     }
 }

--- a/librlox/src/ast/expression.rs
+++ b/librlox/src/ast/expression.rs
@@ -254,9 +254,6 @@ impl std::convert::TryFrom<token::Token> for PrimaryExpr {
             (token::TokenType::Nil, None) => Ok(PrimaryExpr::Nil),
             (token::TokenType::True, None) => Ok(PrimaryExpr::True),
             (token::TokenType::False, None) => Ok(PrimaryExpr::False),
-            (token::TokenType::Identifier, Some(object::Object::Identifier(i))) => {
-                Ok(PrimaryExpr::Identifier(i))
-            }
             (token::TokenType::Str, Some(object::Object::Literal(object::Literal::Str(s)))) => {
                 Ok(PrimaryExpr::Str(s))
             }

--- a/librlox/src/ast/mod.rs
+++ b/librlox/src/ast/mod.rs
@@ -1,6 +1,8 @@
+#[macro_use]
+pub mod token;
+
 pub mod expression;
 pub mod statement;
-pub mod token;
 
 #[cfg(test)]
 mod tests;

--- a/librlox/src/ast/token/mod.rs
+++ b/librlox/src/ast/token/mod.rs
@@ -1,3 +1,4 @@
+#[macro_use]
 pub mod token;
 pub mod token_type;
 

--- a/librlox/src/ast/token/token.rs
+++ b/librlox/src/ast/token/token.rs
@@ -72,3 +72,24 @@ impl fmt::Display for Token {
         }
     }
 }
+
+#[allow(unused_macros)]
+macro_rules! tok_identifier {
+    ($id:expr) => {
+        $crate::ast::token::Token {
+            token_type: $crate::ast::token::TokenType::Identifier,
+            line: 1,
+            lexeme: Option::Some($id.to_string()),
+            object: Option::None,
+        }
+    };
+
+    ($line:literal, $id:expr) => {
+        $crate::ast::token::Token {
+            token_type: $crate::ast::token::TokenType::Identifier,
+            line: $line,
+            lexeme: Option::Some($id.to_string()),
+            object: Option::None,
+        }
+    };
+}

--- a/librlox/src/ast/token/token.rs
+++ b/librlox/src/ast/token/token.rs
@@ -48,8 +48,8 @@ impl Token {
 
     pub fn is_reserved_keyword(&self) -> Option<TokenType> {
         match self.token_type {
-            TokenType::Identifier => match self.object {
-                Some(object::Object::Identifier(ref id)) => {
+            TokenType::Identifier => match self.lexeme {
+                Some(ref id) => {
                     for kw in RESERVED_KEYWORDS.iter() {
                         if kw.0 == id {
                             return Some(kw.1);

--- a/librlox/src/interpreter/interpreter.rs
+++ b/librlox/src/interpreter/interpreter.rs
@@ -1,6 +1,7 @@
 use crate::ast::expression::{
     AdditionExpr, ComparisonExpr, EqualityExpr, Expr, MultiplicationExpr, PrimaryExpr, UnaryExpr,
 };
+use crate::ast::token;
 use crate::environment::Environment;
 use crate::interpreter::InterpreterMut;
 use std::fmt;
@@ -213,19 +214,18 @@ impl StatefulInterpreter {
     }
 
     fn interpret_primary(&mut self, expr: PrimaryExpr) -> ExprInterpreterResult {
-        match expr {
-            PrimaryExpr::Identifier(id) => self.interpret_variable(id),
-            _ => Ok(expr),
-        }
+        Ok(expr)
     }
 
-    fn interpret_variable(&mut self, id: String) -> ExprInterpreterResult {
-        match self.globals.get(&id) {
+    fn interpret_variable(&mut self, identifier: token::Token) -> ExprInterpreterResult {
+        let var = identifier.lexeme.unwrap();
+
+        match self.globals.get(&var) {
             Some(v) => {
                 let expr = v.to_owned();
                 self.interpret(expr)
             }
-            None => Err(ExprInterpreterErr::Lookup(id.clone())),
+            None => Err(ExprInterpreterErr::Lookup(var.clone())),
         }
     }
 }

--- a/librlox/src/interpreter/tests/expression/variable.rs
+++ b/librlox/src/interpreter/tests/expression/variable.rs
@@ -16,8 +16,8 @@ fn declaration_statement_should_set_persistent_global_symbol() {
     assert_eq!(
         Ok(()),
         interpreter.interpret(vec![Stmt::Expression(Expr::Addition(AdditionExpr::Add(
-            Box::new(Expr::Variable("a".to_string())),
-            Box::new(Expr::Variable("b".to_string())),
+            Box::new(Expr::Variable(tok_identifier!("a"))),
+            Box::new(Expr::Variable(tok_identifier!("b"))),
         )))])
     );
 }

--- a/librlox/src/lib.rs
+++ b/librlox/src/lib.rs
@@ -1,7 +1,9 @@
 #[macro_use]
 pub mod object;
 
+#[macro_use]
 pub mod ast;
+
 pub mod environment;
 pub mod interpreter;
 pub mod parser;

--- a/librlox/src/object/mod.rs
+++ b/librlox/src/object/mod.rs
@@ -3,14 +3,12 @@ use std::fmt;
 #[derive(Debug, PartialEq, Clone)]
 pub enum Object {
     Literal(Literal),
-    Identifier(String),
 }
 
 impl fmt::Display for Object {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Object::Literal(l) => write!(f, "{}", &l),
-            Object::Identifier(i) => write!(f, "{}", &i),
         }
     }
 }
@@ -61,12 +59,5 @@ macro_rules! obj_bool {
 macro_rules! obj_nil {
     () => {
         $crate::object::Object::Literal($crate::object::Literal::Nil)
-    };
-}
-
-#[allow(unused_macros)]
-macro_rules! obj_identifier {
-    ($i:expr) => {
-        $crate::object::Object::Identifier($i)
     };
 }

--- a/librlox/src/parser/expression_parser.rs
+++ b/librlox/src/parser/expression_parser.rs
@@ -1,7 +1,6 @@
 extern crate parcel;
 use crate::ast::expression::*;
 use crate::ast::token::{Token, TokenType};
-use crate::object;
 use crate::parser::combinators::{token_type, unzip};
 use parcel::*;
 use std::convert::TryFrom;
@@ -206,12 +205,7 @@ fn primary<'a>() -> impl parcel::Parser<'a, &'a [Token], Expr> {
         .or(|| token_type(TokenType::Number))
         .or(|| token_type(TokenType::Str))
         .map(|token| Expr::Primary(PrimaryExpr::try_from(token).unwrap()))
-        .or(|| {
-            token_type(TokenType::Identifier).map(|token| match token.object {
-                Some(object::Object::Identifier(i)) => Expr::Variable(i),
-                _ => panic!(format!("object not an Identifier: {:?}", token.object)),
-            })
-        })
+        .or(|| token_type(TokenType::Identifier).map(|token| Expr::Variable(token)))
         .or(|| {
             right(join(
                 token_type(TokenType::LeftParen),

--- a/librlox/src/parser/statement_parser.rs
+++ b/librlox/src/parser/statement_parser.rs
@@ -2,7 +2,6 @@ extern crate parcel;
 use super::combinators::token_type;
 use crate::ast::statement::Stmt;
 use crate::ast::token::{Token, TokenType};
-use crate::object;
 use crate::parser::expression_parser::expression;
 use parcel::*;
 
@@ -46,8 +45,8 @@ fn declaration_stmt<'a>() -> impl parcel::Parser<'a, &'a [Token], Stmt> {
         ),
     ))
     .map(|(id_tok, expr)| {
-        let id = match id_tok.object {
-            Some(object::Object::Identifier(i)) => i,
+        let id = match id_tok.lexeme {
+            Some(i) => i,
             _ => panic!("invalid Object specified in place of Identifier"),
         };
 

--- a/librlox/src/parser/tests/statement_parser.rs
+++ b/librlox/src/parser/tests/statement_parser.rs
@@ -13,7 +13,7 @@ fn test_parser_can_parse_declaration_stmt() {
         TokenType::Identifier,
         1,
         Option::Some("test".to_string()),
-        Option::Some(obj_identifier!("test".to_string())),
+        None,
     );
     let literal_token = Token::new(
         TokenType::Number,

--- a/librlox/src/scanner/source_scanner.rs
+++ b/librlox/src/scanner/source_scanner.rs
@@ -410,7 +410,7 @@ impl Scanner {
                         TokenType::Identifier,
                         current.line,
                         Some(ident_literal.trim().to_string()),
-                        Some(obj_identifier!(ident_literal)),
+                        None,
                     );
 
                     return match t.is_reserved_keyword() {

--- a/librlox/src/scanner/source_scanner.rs
+++ b/librlox/src/scanner/source_scanner.rs
@@ -409,7 +409,7 @@ impl Scanner {
                     let t = Token::new(
                         TokenType::Identifier,
                         current.line,
-                        Some(ident_literal.trim().to_string()), // TODO Remove clone
+                        Some(ident_literal.trim().to_string()),
                         Some(obj_identifier!(ident_literal)),
                     );
 

--- a/librlox/src/scanner/tests/token_lexing/helpers.rs
+++ b/librlox/src/scanner/tests/token_lexing/helpers.rs
@@ -24,7 +24,7 @@ pub fn compare_single_token_source_helper(
 pub fn compare_single_token_source_with_literal_helper(
     single_token_source: &str,
     lexeme: &str,
-    obj: object::Object,
+    obj: Option<object::Object>,
     expected_token_type: TokenType,
 ) {
     let source = single_token_source.to_string();
@@ -37,7 +37,7 @@ pub fn compare_single_token_source_with_literal_helper(
             token_type: expected_token_type,
             line: 1,
             lexeme: Some(lexeme.trim().to_string()),
-            object: Some(obj),
+            object: obj,
         })
     );
 }

--- a/librlox/src/scanner/tests/token_lexing/identifiers.rs
+++ b/librlox/src/scanner/tests/token_lexing/identifiers.rs
@@ -1,4 +1,5 @@
 use crate::ast::token::TokenType;
+use std::option::Option;
 
 use super::helpers::{
     compare_single_token_source_helper, compare_single_token_source_with_literal_helper,
@@ -10,7 +11,7 @@ fn scan_tokens_should_lex_identifiers() {
     compare_single_token_source_with_literal_helper(
         identifier,
         identifier,
-        obj_identifier!(identifier.to_string()),
+        Option::None,
         TokenType::Identifier,
     )
 }
@@ -21,7 +22,7 @@ fn scan_tokens_should_separate_identifier_on_non_alpha() {
     compare_single_token_source_with_literal_helper(
         identifier,
         identifier,
-        obj_identifier!(identifier.trim().to_string()),
+        Option::None,
         TokenType::Identifier,
     )
 }

--- a/librlox/src/scanner/tests/token_lexing/numbers.rs
+++ b/librlox/src/scanner/tests/token_lexing/numbers.rs
@@ -8,7 +8,7 @@ fn scan_tokens_should_lex_digit() {
     compare_single_token_source_with_literal_helper(
         "123",
         "123",
-        obj_number!(123.0),
+        Option::Some(obj_number!(123.0)),
         TokenType::Number,
     );
 }
@@ -18,7 +18,7 @@ fn scan_tokens_should_lex_floating_point() {
     compare_single_token_source_with_literal_helper(
         "123.45",
         "123.45",
-        obj_number!(123.45),
+        Option::Some(obj_number!(123.45)),
         TokenType::Number,
     );
 }

--- a/librlox/src/scanner/tests/token_lexing/strings.rs
+++ b/librlox/src/scanner/tests/token_lexing/strings.rs
@@ -8,7 +8,9 @@ fn scan_tokens_should_lex_full_string() {
     compare_single_token_source_with_literal_helper(
         "\"test\"",
         "\"test\"",
-        object::Object::Literal(object::Literal::Str("test".to_string())),
+        Option::Some(object::Object::Literal(object::Literal::Str(
+            "test".to_string(),
+        ))),
         TokenType::Str,
     )
 }


### PR DESCRIPTION
# Introduction
This PR replaces Identifier with a variable expression that references an `Identifier` token as oppose to assigning an identifier to a runtime object.

# Linked Issues
resolves #64 
# Dependencies

# Test
- [x] Tested Locally
- [ ] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
