### PR TITLE
Replace PrimaryExpr with runtime Object type.

### DIFF
--- a/librlox/src/ast/expression.rs
+++ b/librlox/src/ast/expression.rs
@@ -231,7 +231,6 @@ pub enum PrimaryExpr {
     Nil,
     True,
     False,
-    Identifier(String),
     Str(String),
     Number(f64),
 }
@@ -276,7 +275,6 @@ impl fmt::Display for PrimaryExpr {
                 Self::Nil => "nil".to_string(),
                 Self::False => "false".to_string(),
                 Self::True => "true".to_string(),
-                Self::Identifier(v) => v.clone(),
                 Self::Str(v) => v.clone(),
                 Self::Number(v) => format!("{}", v),
             }

--- a/librlox/src/ast/expression.rs
+++ b/librlox/src/ast/expression.rs
@@ -11,7 +11,7 @@ pub enum Expr {
     Addition(AdditionExpr),
     Multiplication(MultiplicationExpr),
     Unary(UnaryExpr),
-    Primary(PrimaryExpr),
+    Primary(object::Object),
     Grouping(Box<Expr>),
     Variable(token::Token),
 }
@@ -37,17 +37,22 @@ impl fmt::Display for Expr {
 /// ```
 /// extern crate librlox;
 /// use librlox::ast::expression::*;
+/// use librlox::object;
 ///
 /// let comparison = Expr::Equality(
 ///     EqualityExpr::NotEqual(
 ///         Box::new(
 ///             Expr::Primary(
-///                 PrimaryExpr::Number(5.0)
+///                 object::Object::Literal(
+///                     object::Literal::Number(5.0)
+///                 )
 ///             )
 ///         ),
 ///         Box::new(
 ///             Expr::Primary(
-///                 PrimaryExpr::Number(5.0)
+///                 object::Object::Literal(
+///                     object::Literal::Number(5.0)
+///                 )
 ///             )
 ///         ),
 ///     )
@@ -74,17 +79,22 @@ impl fmt::Display for EqualityExpr {
 /// ```
 /// extern crate librlox;
 /// use librlox::ast::expression::*;
+/// use librlox::object;
 ///
 /// let comparison = Expr::Comparison(
 ///     ComparisonExpr::GreaterEqual(
 ///         Box::new(
 ///             Expr::Primary(
-///                 PrimaryExpr::Number(5.0)
+///                 object::Object::Literal(
+///                     object::Literal::Number(5.0)
+///                 )
 ///             )
 ///         ),
 ///         Box::new(
 ///             Expr::Primary(
-///                 PrimaryExpr::Number(5.0)
+///                 object::Object::Literal(
+///                     object::Literal::Number(5.0)
+///                 )
 ///             )
 ///         ),
 ///     )
@@ -115,17 +125,22 @@ impl fmt::Display for ComparisonExpr {
 /// ```
 /// extern crate librlox;
 /// use librlox::ast::expression::*;
+/// use librlox::object;
 ///
 /// let addition = Expr::Addition(
 ///     AdditionExpr::Add(
 ///         Box::new(
 ///             Expr::Primary(
-///                 PrimaryExpr::Number(5.0)
+///                 object::Object::Literal(
+///                     object::Literal::Number(5.0)
+///                 )
 ///             )
 ///         ),
 ///         Box::new(
 ///             Expr::Primary(
-///                 PrimaryExpr::Number(5.0)
+///                 object::Object::Literal(
+///                     object::Literal::Number(5.0)
+///                 )
 ///             )
 ///         ),
 ///     )
@@ -152,17 +167,18 @@ impl fmt::Display for AdditionExpr {
 /// ```
 /// extern crate librlox;
 /// use librlox::ast::expression::*;
+/// use librlox::object;
 ///
 /// let multiplication = Expr::Multiplication(
 ///     MultiplicationExpr::Multiply(
 ///         Box::new(
 ///             Expr::Primary(
-///                 PrimaryExpr::Number(5.0)
+///                 object::Object::Literal(object::Literal::Number(5.0))
 ///             )
 ///         ),
 ///         Box::new(
 ///             Expr::Primary(
-///                 PrimaryExpr::Number(5.0)
+///                 object::Object::Literal(object::Literal::Number(5.0))
 ///             )
 ///         ),
 ///     )
@@ -189,12 +205,13 @@ impl fmt::Display for MultiplicationExpr {
 /// ```
 /// extern crate librlox;
 /// use librlox::ast::expression::*;
+/// use librlox::object;
 ///
 /// let unary = Expr::Unary(
 ///     UnaryExpr::Minus(
 ///         Box::new(
 ///             Expr::Primary(
-///                 PrimaryExpr::Number(5.0)
+///                 object::Object::Literal(object::Literal::Number(5.0))
 ///             )
 ///         )
 ///     )
@@ -212,72 +229,5 @@ impl fmt::Display for UnaryExpr {
             Self::Bang(expr) => write!(f, "(! {})", expr),
             Self::Minus(expr) => write!(f, "(- {})", expr),
         }
-    }
-}
-
-/// Represents Literal Lox expressions and stores a single.
-///
-/// # Examples
-/// ```
-/// extern crate librlox;
-/// use librlox::ast::expression::*;
-///
-/// let primary = Expr::Primary(
-///     PrimaryExpr::Number(5.0)
-/// );
-/// ```
-#[derive(Debug, PartialEq, Clone)]
-pub enum PrimaryExpr {
-    Nil,
-    True,
-    False,
-    Str(String),
-    Number(f64),
-}
-
-impl std::convert::From<bool> for PrimaryExpr {
-    fn from(b: bool) -> Self {
-        if b {
-            PrimaryExpr::True
-        } else {
-            PrimaryExpr::False
-        }
-    }
-}
-
-impl std::convert::TryFrom<token::Token> for PrimaryExpr {
-    type Error = String;
-
-    fn try_from(t: token::Token) -> Result<Self, Self::Error> {
-        match (t.token_type, t.object) {
-            (token::TokenType::Nil, None) => Ok(PrimaryExpr::Nil),
-            (token::TokenType::True, None) => Ok(PrimaryExpr::True),
-            (token::TokenType::False, None) => Ok(PrimaryExpr::False),
-            (token::TokenType::Str, Some(object::Object::Literal(object::Literal::Str(s)))) => {
-                Ok(PrimaryExpr::Str(s))
-            }
-            (
-                token::TokenType::Number,
-                Some(object::Object::Literal(object::Literal::Number(n))),
-            ) => Ok(PrimaryExpr::Number(n)),
-            // Placeholder
-            _ => Err(format!("invalid token: {}", t.token_type)),
-        }
-    }
-}
-
-impl fmt::Display for PrimaryExpr {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                Self::Nil => "nil".to_string(),
-                Self::False => "false".to_string(),
-                Self::True => "true".to_string(),
-                Self::Str(v) => v.clone(),
-                Self::Number(v) => format!("{}", v),
-            }
-        )
     }
 }

--- a/librlox/src/ast/tests/ast.rs
+++ b/librlox/src/ast/tests/ast.rs
@@ -1,30 +1,13 @@
-use crate::ast::expression::{Expr, MultiplicationExpr, PrimaryExpr, UnaryExpr};
+use crate::ast::expression::{Expr, MultiplicationExpr, UnaryExpr};
 use crate::ast::statement::Stmt;
-use crate::ast::token::{Token, TokenType};
-use std::convert::TryFrom;
-use std::option::Option;
 
 #[test]
 fn test_expression_formatter_should_pretty_print_an_ast() {
     let expr = Expr::Multiplication(MultiplicationExpr::Multiply(
         Box::new(Expr::Unary(UnaryExpr::Minus(Box::new(Expr::Primary(
-            PrimaryExpr::try_from(Token::new(
-                TokenType::Number,
-                1,
-                Option::Some("123.0".to_string()),
-                Option::Some(obj_number!(123.0)),
-            ))
-            .unwrap(),
+            obj_number!(123.0),
         ))))),
-        Box::new(Expr::Grouping(Box::new(Expr::Primary(
-            PrimaryExpr::try_from(Token::new(
-                TokenType::Number,
-                1,
-                Option::Some("45.7".to_string()),
-                Option::Some(obj_number!(45.7)),
-            ))
-            .unwrap(),
-        )))),
+        Box::new(Expr::Grouping(Box::new(Expr::Primary(obj_number!(45.7))))),
     ));
 
     assert_eq!(
@@ -36,13 +19,7 @@ fn test_expression_formatter_should_pretty_print_an_ast() {
 #[test]
 fn test_statement_formatter_should_pretty_print_an_ast() {
     let expr = Stmt::Expression(Expr::Unary(UnaryExpr::Minus(Box::new(Expr::Primary(
-        PrimaryExpr::try_from(Token::new(
-            TokenType::Number,
-            1,
-            Option::Some("123.0".to_string()),
-            Option::Some(obj_number!(123.0)),
-        ))
-        .unwrap(),
+        obj_number!(123.0),
     )))));
 
     assert_eq!("(Expression (- 123))".to_string(), format!("{}", expr))

--- a/librlox/src/environment/tests/mod.rs
+++ b/librlox/src/environment/tests/mod.rs
@@ -1,4 +1,4 @@
-use crate::ast::expression::{Expr, PrimaryExpr};
+use crate::ast::expression::Expr;
 use crate::environment::Environment;
 use std::option::Option;
 
@@ -8,14 +8,14 @@ fn environment_should_allow_setting_of_symbols() {
 
     // unset var returns None
     assert_eq!(
-        symtable.define("test".to_string(), Expr::Primary(PrimaryExpr::True)),
+        symtable.define("test".to_string(), Expr::Primary(obj_bool!(true))),
         Option::None
     );
 
     // Subsequent returns previous value
     assert_eq!(
-        symtable.define("test".to_string(), Expr::Primary(PrimaryExpr::True)),
-        Option::Some(Expr::Primary(PrimaryExpr::True))
+        symtable.define("test".to_string(), Expr::Primary(obj_bool!(true))),
+        Option::Some(Expr::Primary(obj_bool!(true)))
     );
 }
 
@@ -25,12 +25,12 @@ fn environment_should_allow_getting_of_symbols() {
     let key = "test".to_string();
 
     assert_eq!(
-        symtable.define(key.clone(), Expr::Primary(PrimaryExpr::True)),
+        symtable.define(key.clone(), Expr::Primary(obj_bool!(true))),
         Option::None
     );
 
     assert_eq!(
         symtable.get(&key),
-        Option::Some(&Expr::Primary(PrimaryExpr::True))
+        Option::Some(&Expr::Primary(obj_bool!(true)))
     );
 }

--- a/librlox/src/interpreter/tests/expression/addition.rs
+++ b/librlox/src/interpreter/tests/expression/addition.rs
@@ -1,10 +1,12 @@
-use crate::ast::expression::{AdditionExpr, Expr, MultiplicationExpr, PrimaryExpr};
+use crate::ast::expression::{AdditionExpr, Expr, MultiplicationExpr};
 use crate::interpreter::InterpreterMut;
 use crate::interpreter::StatefulInterpreter;
 
 macro_rules! primary_number {
     ($x:literal) => {
-        Expr::Primary(PrimaryExpr::Number($x))
+        Expr::Primary($crate::object::Object::Literal(
+            $crate::object::Literal::Number($x),
+        ))
     };
 }
 
@@ -25,11 +27,8 @@ fn addition_expr_should_evaluate_when_both_operands_are_numbers() {
         Box::new(primary_number!(2.0)),
     ));
 
-    assert_eq!(Ok(PrimaryExpr::Number(7.0)), expr_interpret!(addition_expr));
-    assert_eq!(
-        Ok(PrimaryExpr::Number(5.0)),
-        expr_interpret!(subtraction_expr)
-    );
+    assert_eq!(Ok(obj_number!(7.0)), expr_interpret!(addition_expr));
+    assert_eq!(Ok(obj_number!(5.0)), expr_interpret!(subtraction_expr));
 }
 
 #[test]
@@ -42,18 +41,15 @@ fn addition_expr_should_maintain_operator_precedence() {
         Box::new(primary_number!(1.0)),
     ));
 
-    assert_eq!(Ok(PrimaryExpr::Number(-4.0)), expr_interpret!(expr));
+    assert_eq!(Ok(obj_number!(-4.0)), expr_interpret!(expr));
 }
 
 #[test]
 fn addition_expr_should_concatenate_strings() {
     let expr = Expr::Addition(AdditionExpr::Add(
-        Box::new(Expr::Primary(PrimaryExpr::Str("hello".to_string()))),
-        Box::new(Expr::Primary(PrimaryExpr::Str("world".to_string()))),
+        Box::new(Expr::Primary(obj_str!("hello".to_string()))),
+        Box::new(Expr::Primary(obj_str!("world".to_string()))),
     ));
 
-    assert_eq!(
-        Ok(PrimaryExpr::Str(format!("helloworld"))),
-        expr_interpret!(expr)
-    );
+    assert_eq!(Ok(obj_str!(format!("helloworld"))), expr_interpret!(expr));
 }

--- a/librlox/src/interpreter/tests/expression/comparison.rs
+++ b/librlox/src/interpreter/tests/expression/comparison.rs
@@ -1,10 +1,12 @@
-use crate::ast::expression::{ComparisonExpr, Expr, MultiplicationExpr, PrimaryExpr};
+use crate::ast::expression::{ComparisonExpr, Expr, MultiplicationExpr};
 use crate::interpreter::InterpreterMut;
 use crate::interpreter::StatefulInterpreter;
 
 macro_rules! primary_number {
     ($x:literal) => {
-        Expr::Primary(PrimaryExpr::Number($x))
+        Expr::Primary($crate::object::Object::Literal(
+            $crate::object::Literal::Number($x),
+        ))
     };
 }
 
@@ -33,10 +35,10 @@ fn comparison_expr_should_evaluate_when_both_operands_are_numbers() {
         Box::new(primary_number!(5.0)),
     ));
 
-    assert_eq!(Ok(PrimaryExpr::False), expr_interpret!(less_expr));
-    assert_eq!(Ok(PrimaryExpr::True), expr_interpret!(less_equal_expr));
-    assert_eq!(Ok(PrimaryExpr::False), expr_interpret!(greater_expr));
-    assert_eq!(Ok(PrimaryExpr::True), expr_interpret!(greater_equal_expr));
+    assert_eq!(Ok(obj_bool!(false)), expr_interpret!(less_expr));
+    assert_eq!(Ok(obj_bool!(true)), expr_interpret!(less_equal_expr));
+    assert_eq!(Ok(obj_bool!(false)), expr_interpret!(greater_expr));
+    assert_eq!(Ok(obj_bool!(true)), expr_interpret!(greater_equal_expr));
 }
 
 #[test]
@@ -49,5 +51,5 @@ fn comparison_expr_should_maintain_operator_precedence() {
         Box::new(primary_number!(1.0)),
     ));
 
-    assert_eq!(Ok(PrimaryExpr::True), expr_interpret!(expr));
+    assert_eq!(Ok(obj_bool!(true)), expr_interpret!(expr));
 }

--- a/librlox/src/interpreter/tests/expression/equality.rs
+++ b/librlox/src/interpreter/tests/expression/equality.rs
@@ -1,16 +1,20 @@
-use crate::ast::expression::{EqualityExpr, Expr, MultiplicationExpr, PrimaryExpr};
+use crate::ast::expression::{EqualityExpr, Expr, MultiplicationExpr};
 use crate::interpreter::InterpreterMut;
 use crate::interpreter::StatefulInterpreter;
 
 macro_rules! primary_number {
     ($x:literal) => {
-        Expr::Primary(PrimaryExpr::Number($x))
+        Expr::Primary($crate::object::Object::Literal(
+            $crate::object::Literal::Number($x),
+        ))
     };
 }
 
 macro_rules! primary_string {
     ($x:literal) => {
-        Expr::Primary(PrimaryExpr::Str($x.to_string()))
+        Expr::Primary($crate::object::Object::Literal(
+            $crate::object::Literal::Str($x.to_string()),
+        ))
     };
 }
 
@@ -39,10 +43,10 @@ fn equality_expr_should_evaluate_when_both_operands_are_numbers() {
         Box::new(primary_number!(5.0)),
     ));
 
-    assert_eq!(Ok(PrimaryExpr::True), expr_interpret!(less_expr));
-    assert_eq!(Ok(PrimaryExpr::False), expr_interpret!(less_equal_expr));
-    assert_eq!(Ok(PrimaryExpr::True), expr_interpret!(greater_expr));
-    assert_eq!(Ok(PrimaryExpr::False), expr_interpret!(greater_equal_expr));
+    assert_eq!(Ok(obj_bool!(true)), expr_interpret!(less_expr));
+    assert_eq!(Ok(obj_bool!(false)), expr_interpret!(less_equal_expr));
+    assert_eq!(Ok(obj_bool!(true)), expr_interpret!(greater_expr));
+    assert_eq!(Ok(obj_bool!(false)), expr_interpret!(greater_equal_expr));
 }
 
 #[test]
@@ -64,10 +68,10 @@ fn equality_expr_should_evaluate_when_both_operands_are_strings() {
         Box::new(primary_string!("hello")),
     ));
 
-    assert_eq!(Ok(PrimaryExpr::True), expr_interpret!(less_expr));
-    assert_eq!(Ok(PrimaryExpr::False), expr_interpret!(less_equal_expr));
-    assert_eq!(Ok(PrimaryExpr::True), expr_interpret!(greater_expr));
-    assert_eq!(Ok(PrimaryExpr::False), expr_interpret!(greater_equal_expr));
+    assert_eq!(Ok(obj_bool!(true)), expr_interpret!(less_expr));
+    assert_eq!(Ok(obj_bool!(false)), expr_interpret!(less_equal_expr));
+    assert_eq!(Ok(obj_bool!(true)), expr_interpret!(greater_expr));
+    assert_eq!(Ok(obj_bool!(false)), expr_interpret!(greater_equal_expr));
 }
 
 #[test]
@@ -80,5 +84,5 @@ fn equality_expr_should_maintain_operator_precedence() {
         Box::new(primary_number!(1.0)),
     ));
 
-    assert_eq!(Ok(PrimaryExpr::True), expr_interpret!(expr));
+    assert_eq!(Ok(obj_bool!(true)), expr_interpret!(expr));
 }

--- a/librlox/src/interpreter/tests/expression/grouping.rs
+++ b/librlox/src/interpreter/tests/expression/grouping.rs
@@ -1,10 +1,12 @@
-use crate::ast::expression::{AdditionExpr, Expr, MultiplicationExpr, PrimaryExpr};
+use crate::ast::expression::{AdditionExpr, Expr, MultiplicationExpr};
 use crate::interpreter::InterpreterMut;
 use crate::interpreter::StatefulInterpreter;
 
 macro_rules! primary_number {
     ($x:literal) => {
-        Expr::Primary(PrimaryExpr::Number($x))
+        Expr::Primary($crate::object::Object::Literal(
+            $crate::object::Literal::Number($x),
+        ))
     };
 }
 
@@ -25,7 +27,7 @@ fn grouping_expr_should_interpret_to_equivalent_primary() {
     let expr = Expr::Grouping(Box::new(primary_number!(5.0)));
 
     assert_eq!(
-        Ok(PrimaryExpr::Number(5.0)),
+        Ok(obj_number!(5.0)),
         StatefulInterpreter::new().interpret(expr)
     );
 }
@@ -41,7 +43,7 @@ fn grouping_expr_should_maintain_operator_precedence() {
     );
 
     assert_eq!(
-        Ok(PrimaryExpr::Number(5.0)),
+        Ok(obj_number!(5.0)),
         StatefulInterpreter::new().interpret(expr)
     );
 }

--- a/librlox/src/interpreter/tests/expression/multiplication.rs
+++ b/librlox/src/interpreter/tests/expression/multiplication.rs
@@ -1,17 +1,21 @@
-use crate::ast::expression::{Expr, MultiplicationExpr, PrimaryExpr, UnaryExpr};
+use crate::ast::expression::{Expr, MultiplicationExpr, UnaryExpr};
 use crate::interpreter::ExprInterpreterErr;
 use crate::interpreter::InterpreterMut;
 use crate::interpreter::StatefulInterpreter;
 
 macro_rules! primary_number {
     ($x:literal) => {
-        Expr::Primary(PrimaryExpr::Number($x))
+        Expr::Primary($crate::object::Object::Literal(
+            $crate::object::Literal::Number($x),
+        ))
     };
 }
 
 macro_rules! primary_string {
-    ($s:literal) => {
-        Expr::Primary(PrimaryExpr::Str($s.to_string()))
+    ($x:literal) => {
+        Expr::Primary($crate::object::Object::Literal(
+            $crate::object::Literal::Str($x.to_string()),
+        ))
     };
 }
 
@@ -32,8 +36,8 @@ fn multiplication_expr_should_evaluate_when_both_operands_are_numbers() {
         Box::new(primary_number!(2.0)),
     ));
 
-    assert_eq!(Ok(PrimaryExpr::Number(10.0)), expr_interpret!(product_expr));
-    assert_eq!(Ok(PrimaryExpr::Number(5.0)), expr_interpret!(division_expr));
+    assert_eq!(Ok(obj_number!(10.0)), expr_interpret!(product_expr));
+    assert_eq!(Ok(obj_number!(5.0)), expr_interpret!(division_expr));
 }
 
 #[test]
@@ -45,8 +49,8 @@ fn multiplication_expr_should_err_when_operands_are_not_numbers() {
     assert_eq!(
         Err(ExprInterpreterErr::BinaryExpr(
             "*",
-            PrimaryExpr::Str("hello".to_string()),
-            PrimaryExpr::Str("world".to_string()),
+            obj_str!("hello".to_string()),
+            obj_str!("world".to_string()),
         )),
         expr_interpret!(expr)
     );
@@ -61,5 +65,5 @@ fn multiplication_expr_should_maintain_operator_precedence() {
         ))))),
     ));
 
-    assert_eq!(Ok(PrimaryExpr::Number(-5.0)), expr_interpret!(expr));
+    assert_eq!(Ok(obj_number!(-5.0)), expr_interpret!(expr));
 }

--- a/librlox/src/interpreter/tests/expression/primary.rs
+++ b/librlox/src/interpreter/tests/expression/primary.rs
@@ -1,13 +1,13 @@
-use crate::ast::expression::{Expr, PrimaryExpr};
+use crate::ast::expression::Expr;
 use crate::interpreter::InterpreterMut;
 use crate::interpreter::StatefulInterpreter;
 
 #[test]
 fn primary_expr_should_interpret_to_equivalent_primary() {
-    let expr = Expr::Primary(PrimaryExpr::Number(5.0));
+    let expr = Expr::Primary(obj_number!(5.0));
 
     assert_eq!(
-        Ok(PrimaryExpr::Number(5.0)),
+        Ok(obj_number!(5.0)),
         StatefulInterpreter::new().interpret(expr)
     );
 }

--- a/librlox/src/interpreter/tests/expression/unary.rs
+++ b/librlox/src/interpreter/tests/expression/unary.rs
@@ -1,30 +1,28 @@
-use crate::ast::expression::{Expr, PrimaryExpr, UnaryExpr};
+use crate::ast::expression::{Expr, UnaryExpr};
 use crate::interpreter::InterpreterMut;
 use crate::interpreter::StatefulInterpreter;
 
 #[test]
 fn unary_expr_should_invert_bool_with_bang_operator() {
-    let true_expr = Expr::Unary(UnaryExpr::Bang(Box::new(Expr::Primary(PrimaryExpr::True))));
-    let false_expr = Expr::Unary(UnaryExpr::Bang(Box::new(Expr::Primary(PrimaryExpr::False))));
+    let true_expr = Expr::Unary(UnaryExpr::Bang(Box::new(Expr::Primary(obj_bool!(true)))));
+    let false_expr = Expr::Unary(UnaryExpr::Bang(Box::new(Expr::Primary(obj_bool!(false)))));
 
     assert_eq!(
-        Ok(PrimaryExpr::False),
+        Ok(obj_bool!(false)),
         StatefulInterpreter::new().interpret(true_expr)
     );
     assert_eq!(
-        Ok(PrimaryExpr::True),
+        Ok(obj_bool!(true)),
         StatefulInterpreter::new().interpret(false_expr)
     );
 }
 
 #[test]
 fn unary_expr_should_negate_number_with_minus_operator() {
-    let expr = Expr::Unary(UnaryExpr::Minus(Box::new(Expr::Primary(
-        PrimaryExpr::Number(1.0),
-    ))));
+    let expr = Expr::Unary(UnaryExpr::Minus(Box::new(Expr::Primary(obj_number!(1.0)))));
 
     assert_eq!(
-        Ok(PrimaryExpr::Number(-1.0)),
+        Ok(obj_number!(-1.0)),
         StatefulInterpreter::new().interpret(expr)
     );
 }

--- a/librlox/src/interpreter/tests/expression/variable.rs
+++ b/librlox/src/interpreter/tests/expression/variable.rs
@@ -1,4 +1,4 @@
-use crate::ast::expression::{AdditionExpr, Expr, PrimaryExpr};
+use crate::ast::expression::{AdditionExpr, Expr};
 use crate::ast::statement::Stmt;
 use crate::interpreter::InterpreterMut;
 use crate::interpreter::StatefulInterpreter;
@@ -8,10 +8,10 @@ fn declaration_statement_should_set_persistent_global_symbol() {
     let mut interpreter = StatefulInterpreter::new();
     interpreter
         .globals
-        .define("a".to_string(), Expr::Primary(PrimaryExpr::Number(1.0)));
+        .define("a".to_string(), Expr::Primary(obj_number!(1.0)));
     interpreter
         .globals
-        .define("b".to_string(), Expr::Primary(PrimaryExpr::Number(2.0)));
+        .define("b".to_string(), Expr::Primary(obj_number!(2.0)));
 
     assert_eq!(
         Ok(()),

--- a/librlox/src/interpreter/tests/statement/mod.rs
+++ b/librlox/src/interpreter/tests/statement/mod.rs
@@ -1,4 +1,4 @@
-use crate::ast::expression::{Expr, PrimaryExpr};
+use crate::ast::expression::Expr;
 use crate::ast::statement::Stmt;
 use crate::interpreter::InterpreterMut;
 use crate::interpreter::StatefulInterpreter;
@@ -8,7 +8,7 @@ fn expression_stmt_should_return_ok() {
     assert_eq!(
         Ok(()),
         StatefulInterpreter::new()
-            .interpret(vec![Stmt::Expression(Expr::Primary(PrimaryExpr::True))])
+            .interpret(vec![Stmt::Expression(Expr::Primary(obj_bool!(true)))])
     );
 }
 
@@ -16,17 +16,17 @@ fn expression_stmt_should_return_ok() {
 fn print_stmt_should_return_ok() {
     assert_eq!(
         Ok(()),
-        StatefulInterpreter::new().interpret(vec![Stmt::Print(Expr::Primary(PrimaryExpr::True))])
+        StatefulInterpreter::new().interpret(vec![Stmt::Print(Expr::Primary(obj_bool!(true)))])
     );
 }
 
 #[test]
 fn declaration_statement_should_set_persistent_global_symbol() {
-    let stmt = Stmt::Declaration("test".to_string(), Expr::Primary(PrimaryExpr::True));
+    let stmt = Stmt::Declaration("test".to_string(), Expr::Primary(obj_bool!(true)));
     let mut interpreter = StatefulInterpreter::new();
     interpreter.interpret(vec![stmt]).unwrap();
     assert_eq!(
-        Some(&Expr::Primary(PrimaryExpr::True)),
+        Some(&Expr::Primary(obj_bool!(true))),
         interpreter.globals.get(&"test".to_string())
     );
 }

--- a/librlox/src/object/mod.rs
+++ b/librlox/src/object/mod.rs
@@ -1,8 +1,20 @@
 use std::fmt;
 
+pub trait Truthy {
+    fn is_truthy(&self) -> bool;
+}
+
 #[derive(Debug, PartialEq, Clone)]
 pub enum Object {
     Literal(Literal),
+}
+
+impl Truthy for Object {
+    fn is_truthy(&self) -> bool {
+        match self {
+            Self::Literal(l) => l.is_truthy(),
+        }
+    }
 }
 
 impl fmt::Display for Object {
@@ -21,6 +33,35 @@ pub enum Literal {
     Bool(bool),
     Str(String),
     Number(f64),
+}
+
+impl std::convert::From<bool> for Literal {
+    fn from(b: bool) -> Self {
+        Literal::Bool(b)
+    }
+}
+
+impl std::convert::From<String> for Literal {
+    fn from(s: String) -> Self {
+        Literal::Str(s)
+    }
+}
+
+impl std::convert::From<f64> for Literal {
+    fn from(f: f64) -> Self {
+        Literal::Number(f)
+    }
+}
+
+impl Truthy for Literal {
+    fn is_truthy(&self) -> bool {
+        match self {
+            Self::Nil => false,
+            Self::Bool(b) => *b,
+            Self::Str(s) => !s.is_empty(),
+            Self::Number(n) => n.abs() < std::f64::EPSILON,
+        }
+    }
 }
 
 impl fmt::Display for Literal {

--- a/librlox/src/parser/expression_parser.rs
+++ b/librlox/src/parser/expression_parser.rs
@@ -3,7 +3,6 @@ use crate::ast::expression::*;
 use crate::ast::token::{Token, TokenType};
 use crate::parser::combinators::{token_type, unzip};
 use parcel::*;
-use std::convert::TryFrom;
 
 /// Represents the entrypoint for expression parsing within the lox parser and
 /// yields an Expr object after recursively descending through the expression
@@ -30,10 +29,7 @@ use std::convert::TryFrom;
 /// assert_eq!(
 ///     Ok(MatchStatus::Match((
 ///         &seed_vec[1..],
-///         Expr::Primary(
-///             PrimaryExpr::try_from(
-///                 literal_token.clone()
-///             ).unwrap()
+///         Expr::Primary(object::Object::Literal(object::Literal::Number(1.0))
 ///         )
 ///     ))),
 ///     expression().parse(&seed_vec)
@@ -204,7 +200,7 @@ fn primary<'a>() -> impl parcel::Parser<'a, &'a [Token], Expr> {
         .or(|| token_type(TokenType::Nil))
         .or(|| token_type(TokenType::Number))
         .or(|| token_type(TokenType::Str))
-        .map(|token| Expr::Primary(PrimaryExpr::try_from(token).unwrap()))
+        .map(|token| Expr::Primary(token.object.unwrap()))
         .or(|| token_type(TokenType::Identifier).map(|token| Expr::Variable(token)))
         .or(|| {
             right(join(

--- a/librlox/src/parser/tests/expression_parser.rs
+++ b/librlox/src/parser/tests/expression_parser.rs
@@ -1,11 +1,10 @@
 extern crate parcel;
 use crate::ast::expression::{
-    AdditionExpr, ComparisonExpr, EqualityExpr, Expr, MultiplicationExpr, PrimaryExpr, UnaryExpr,
+    AdditionExpr, ComparisonExpr, EqualityExpr, Expr, MultiplicationExpr, UnaryExpr,
 };
 use crate::ast::token::{Token, TokenType};
 use crate::parser::expression_parser::expression;
 use parcel::*;
-use std::convert::TryFrom;
 
 fn match_literal_helper(token: Token) {
     let seed_vec = vec![token.clone()];
@@ -13,7 +12,7 @@ fn match_literal_helper(token: Token) {
     assert_eq!(
         Ok(MatchStatus::Match((
             &seed_vec[1..],
-            Expr::Primary(PrimaryExpr::try_from(token).unwrap())
+            Expr::Primary(token.object.unwrap())
         ))),
         expression().parse(&seed_vec)
     );
@@ -38,12 +37,8 @@ fn validate_parser_should_parse_equality_expression() {
         Ok(MatchStatus::Match((
             &seed_vec[3..],
             Expr::Equality(EqualityExpr::Equal(
-                Box::new(Expr::Primary(
-                    PrimaryExpr::try_from(literal_token.clone()).unwrap()
-                )),
-                Box::new(Expr::Primary(
-                    PrimaryExpr::try_from(literal_token.clone()).unwrap()
-                ))
+                Box::new(Expr::Primary(obj_number!(1.0))),
+                Box::new(Expr::Primary(obj_number!(1.0)))
             ))
         ))),
         expression().parse(&seed_vec)
@@ -71,16 +66,10 @@ fn validate_parser_should_parse_many_equality_expression() {
         Ok(MatchStatus::Match((
             &seed_vec[5..],
             Expr::Equality(EqualityExpr::Equal(
-                Box::new(Expr::Primary(
-                    PrimaryExpr::try_from(literal_token.clone()).unwrap()
-                )),
+                Box::new(Expr::Primary(obj_number!(1.0))),
                 Box::new(Expr::Equality(EqualityExpr::Equal(
-                    Box::new(Expr::Primary(
-                        PrimaryExpr::try_from(literal_token.clone()).unwrap()
-                    )),
-                    Box::new(Expr::Primary(
-                        PrimaryExpr::try_from(literal_token.clone()).unwrap()
-                    ))
+                    Box::new(Expr::Primary(obj_number!(1.0))),
+                    Box::new(Expr::Primary(obj_number!(1.0)))
                 )))
             ))
         ))),
@@ -107,12 +96,8 @@ fn validate_parser_should_parse_comparison_expression() {
         Ok(MatchStatus::Match((
             &seed_vec[3..],
             Expr::Comparison(ComparisonExpr::GreaterEqual(
-                Box::new(Expr::Primary(
-                    PrimaryExpr::try_from(literal_token.clone()).unwrap()
-                )),
-                Box::new(Expr::Primary(
-                    PrimaryExpr::try_from(literal_token.clone()).unwrap()
-                ))
+                Box::new(Expr::Primary(obj_number!(1.0))),
+                Box::new(Expr::Primary(obj_number!(1.0)))
             ))
         ))),
         expression().parse(&seed_vec)
@@ -140,16 +125,10 @@ fn validate_parser_should_parse_many_comparison_expression() {
         Ok(MatchStatus::Match((
             &seed_vec[5..],
             Expr::Comparison(ComparisonExpr::GreaterEqual(
-                Box::new(Expr::Primary(
-                    PrimaryExpr::try_from(literal_token.clone()).unwrap()
-                )),
+                Box::new(Expr::Primary(obj_number!(1.0))),
                 Box::new(Expr::Comparison(ComparisonExpr::GreaterEqual(
-                    Box::new(Expr::Primary(
-                        PrimaryExpr::try_from(literal_token.clone()).unwrap()
-                    )),
-                    Box::new(Expr::Primary(
-                        PrimaryExpr::try_from(literal_token.clone()).unwrap()
-                    ))
+                    Box::new(Expr::Primary(obj_number!(1.0))),
+                    Box::new(Expr::Primary(obj_number!(1.0)))
                 )))
             ))
         ))),
@@ -176,12 +155,8 @@ fn validate_parser_should_parse_addition_expression() {
         Ok(MatchStatus::Match((
             &seed_vec[3..],
             Expr::Addition(AdditionExpr::Add(
-                Box::new(Expr::Primary(
-                    PrimaryExpr::try_from(literal_token.clone()).unwrap()
-                )),
-                Box::new(Expr::Primary(
-                    PrimaryExpr::try_from(literal_token.clone()).unwrap()
-                ))
+                Box::new(Expr::Primary(obj_number!(1.0))),
+                Box::new(Expr::Primary(obj_number!(1.0)))
             ))
         ))),
         expression().parse(&seed_vec)
@@ -209,16 +184,10 @@ fn validate_parser_should_parse_many_addition_expression() {
         Ok(MatchStatus::Match((
             &seed_vec[5..],
             Expr::Addition(AdditionExpr::Add(
-                Box::new(Expr::Primary(
-                    PrimaryExpr::try_from(literal_token.clone()).unwrap()
-                )),
+                Box::new(Expr::Primary(obj_number!(1.0))),
                 Box::new(Expr::Addition(AdditionExpr::Add(
-                    Box::new(Expr::Primary(
-                        PrimaryExpr::try_from(literal_token.clone()).unwrap()
-                    )),
-                    Box::new(Expr::Primary(
-                        PrimaryExpr::try_from(literal_token.clone()).unwrap()
-                    ))
+                    Box::new(Expr::Primary(obj_number!(1.0))),
+                    Box::new(Expr::Primary(obj_number!(1.0)))
                 )))
             ))
         ))),
@@ -245,12 +214,8 @@ fn validate_parser_should_parse_multiplication_expression() {
         Ok(MatchStatus::Match((
             &seed_vec[3..],
             Expr::Multiplication(MultiplicationExpr::Multiply(
-                Box::new(Expr::Primary(
-                    PrimaryExpr::try_from(literal_token.clone()).unwrap()
-                )),
-                Box::new(Expr::Primary(
-                    PrimaryExpr::try_from(literal_token.clone()).unwrap()
-                ))
+                Box::new(Expr::Primary(obj_number!(1.0))),
+                Box::new(Expr::Primary(obj_number!(1.0)))
             ))
         ))),
         expression().parse(&seed_vec)
@@ -278,16 +243,10 @@ fn validate_parser_should_parse_many_multiplication_expression() {
         Ok(MatchStatus::Match((
             &seed_vec[5..],
             Expr::Multiplication(MultiplicationExpr::Multiply(
-                Box::new(Expr::Primary(
-                    PrimaryExpr::try_from(literal_token.clone()).unwrap()
-                )),
+                Box::new(Expr::Primary(obj_number!(1.0))),
                 Box::new(Expr::Multiplication(MultiplicationExpr::Multiply(
-                    Box::new(Expr::Primary(
-                        PrimaryExpr::try_from(literal_token.clone()).unwrap()
-                    )),
-                    Box::new(Expr::Primary(
-                        PrimaryExpr::try_from(literal_token.clone()).unwrap()
-                    ))
+                    Box::new(Expr::Primary(obj_number!(1.0))),
+                    Box::new(Expr::Primary(obj_number!(1.0)))
                 )))
             ))
         ))),
@@ -309,9 +268,7 @@ fn validate_parser_should_parse_unary_expression() {
     assert_eq!(
         Ok(MatchStatus::Match((
             &seed_vec[2..],
-            Expr::Unary(UnaryExpr::Bang(Box::new(Expr::Primary(
-                PrimaryExpr::try_from(literal_token).unwrap()
-            ))))
+            Expr::Unary(UnaryExpr::Bang(Box::new(Expr::Primary(obj_number!(1.0)))))
         ))),
         expression().parse(&seed_vec)
     );
@@ -344,9 +301,7 @@ fn validate_parser_should_parse_grouping_expression() {
     assert_eq!(
         Ok(MatchStatus::Match((
             &seed_vec[3..],
-            Expr::Grouping(Box::new(Expr::Primary(
-                PrimaryExpr::try_from(literal_token).unwrap()
-            )))
+            Expr::Grouping(Box::new(Expr::Primary(obj_number!(1.0))))
         ))),
         expression().parse(&seed_vec)
     );

--- a/librlox/src/parser/tests/statement_parser.rs
+++ b/librlox/src/parser/tests/statement_parser.rs
@@ -1,5 +1,5 @@
 extern crate parcel;
-use crate::ast::expression::{Expr, PrimaryExpr};
+use crate::ast::expression::Expr;
 use crate::ast::statement::Stmt;
 use crate::ast::token::{Token, TokenType};
 use crate::parser::statement_parser::statements;
@@ -34,7 +34,7 @@ fn test_parser_can_parse_declaration_stmt() {
             &input[5..],
             vec![Stmt::Declaration(
                 "test".to_string(),
-                Expr::Primary(PrimaryExpr::Number(5.0))
+                Expr::Primary(obj_number!(5.0))
             )]
         ))),
         statements().parse(&input)


### PR DESCRIPTION
# Introduction
This PR removes the PrimaryExpr type in favor of having expressions, and by extension symbols, evaluate back to runtime Objects.

# Linked Issues
resolves #62 

# Dependencies

# Test
- [x] Tested Locally
- [ ] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
