### PR TITLE
Switch Environment to store runtime objects.

### DIFF
--- a/librlox/src/environment/mod.rs
+++ b/librlox/src/environment/mod.rs
@@ -1,4 +1,4 @@
-use crate::ast::expression::Expr;
+use crate::object;
 use std::collections::HashMap;
 
 #[cfg(test)]
@@ -7,7 +7,7 @@ mod tests;
 /// Functions as a symbols table for looking up variables assignments.
 #[derive(Default, Debug)]
 pub struct Environment {
-    symbols_table: HashMap<String, Expr>,
+    symbols_table: HashMap<String, object::Object>,
 }
 
 impl Environment {
@@ -15,11 +15,11 @@ impl Environment {
         Self::default()
     }
 
-    pub fn define(&mut self, name: String, value: Expr) -> Option<Expr> {
+    pub fn define(&mut self, name: String, value: object::Object) -> Option<object::Object> {
         self.symbols_table.insert(name, value)
     }
 
-    pub fn get(&mut self, name: &String) -> Option<&Expr> {
+    pub fn get(&mut self, name: &String) -> Option<&object::Object> {
         self.symbols_table.get(name)
     }
 }

--- a/librlox/src/environment/tests/mod.rs
+++ b/librlox/src/environment/tests/mod.rs
@@ -1,4 +1,3 @@
-use crate::ast::expression::Expr;
 use crate::environment::Environment;
 use std::option::Option;
 
@@ -8,14 +7,14 @@ fn environment_should_allow_setting_of_symbols() {
 
     // unset var returns None
     assert_eq!(
-        symtable.define("test".to_string(), Expr::Primary(obj_bool!(true))),
+        symtable.define("test".to_string(), obj_bool!(true)),
         Option::None
     );
 
     // Subsequent returns previous value
     assert_eq!(
-        symtable.define("test".to_string(), Expr::Primary(obj_bool!(true))),
-        Option::Some(Expr::Primary(obj_bool!(true)))
+        symtable.define("test".to_string(), obj_bool!(true)),
+        Option::Some(obj_bool!(true))
     );
 }
 
@@ -24,13 +23,7 @@ fn environment_should_allow_getting_of_symbols() {
     let mut symtable = Environment::new();
     let key = "test".to_string();
 
-    assert_eq!(
-        symtable.define(key.clone(), Expr::Primary(obj_bool!(true))),
-        Option::None
-    );
+    assert_eq!(symtable.define(key.clone(), obj_bool!(true)), Option::None);
 
-    assert_eq!(
-        symtable.get(&key),
-        Option::Some(&Expr::Primary(obj_bool!(true)))
-    );
+    assert_eq!(symtable.get(&key), Option::Some(&obj_bool!(true)));
 }

--- a/librlox/src/interpreter/interpreter.rs
+++ b/librlox/src/interpreter/interpreter.rs
@@ -237,10 +237,7 @@ impl StatefulInterpreter {
         let var = identifier.lexeme.unwrap();
 
         match self.globals.get(&var) {
-            Some(v) => {
-                let expr = v.to_owned();
-                self.interpret(expr)
-            }
+            Some(v) => Ok(v.to_owned()),
             None => Err(ExprInterpreterErr::Lookup(var.clone())),
         }
     }
@@ -319,8 +316,8 @@ impl StatefulInterpreter {
 
     fn interpret_declaration_stmt(&mut self, name: String, expr: Expr) -> StmtInterpreterResult {
         match self.interpret(expr) {
-            Ok(expr) => {
-                self.globals.define(name, Expr::Primary(expr));
+            Ok(obj) => {
+                self.globals.define(name, obj);
                 Ok(())
             }
             Err(e) => Err(StmtInterpreterErr::Expression(e)),

--- a/librlox/src/interpreter/tests/expression/variable.rs
+++ b/librlox/src/interpreter/tests/expression/variable.rs
@@ -8,10 +8,10 @@ fn declaration_statement_should_set_persistent_global_symbol() {
     let mut interpreter = StatefulInterpreter::new();
     interpreter
         .globals
-        .define("a".to_string(), Expr::Primary(obj_number!(1.0)));
+        .define("a".to_string(), obj_number!(1.0));
     interpreter
         .globals
-        .define("b".to_string(), Expr::Primary(obj_number!(2.0)));
+        .define("b".to_string(), obj_number!(2.0));
 
     assert_eq!(
         Ok(()),

--- a/librlox/src/interpreter/tests/statement/mod.rs
+++ b/librlox/src/interpreter/tests/statement/mod.rs
@@ -26,7 +26,7 @@ fn declaration_statement_should_set_persistent_global_symbol() {
     let mut interpreter = StatefulInterpreter::new();
     interpreter.interpret(vec![stmt]).unwrap();
     assert_eq!(
-        Some(&Expr::Primary(obj_bool!(true))),
+        Some(&obj_bool!(true)),
         interpreter.globals.get(&"test".to_string())
     );
 }


### PR DESCRIPTION
# Introduction
This PR completes the work of #66, updating the Environment to store runtime objects instead of Expr.
# Linked Issues
resolves #62 
# Dependencies

# Test
- [x] Tested Locally
- [ ] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
