### PR TITLE
remove Truthy trait in favor of Into<bool>.

### DIFF
--- a/librlox/src/interpreter/interpreter.rs
+++ b/librlox/src/interpreter/interpreter.rs
@@ -4,7 +4,6 @@ use crate::ast::expression::{
 use crate::ast::token;
 use crate::environment::Environment;
 use crate::interpreter::InterpreterMut;
-use crate::object::Truthy;
 use crate::object::{Literal, Object};
 use std::fmt;
 
@@ -218,7 +217,10 @@ impl StatefulInterpreter {
     fn interpret_unary(&mut self, expr: UnaryExpr) -> ExprInterpreterResult {
         match expr {
             UnaryExpr::Bang(ue) => match self.interpret(ue) {
-                Ok(obj) => Ok(obj_bool!(!obj.is_truthy())),
+                Ok(obj) => {
+                    let ob: bool = obj.into();
+                    Ok(obj_bool!(!ob))
+                }
                 e @ Err(_) => e,
             },
             UnaryExpr::Minus(ue) => match self.interpret(ue) {

--- a/librlox/src/object/mod.rs
+++ b/librlox/src/object/mod.rs
@@ -1,18 +1,17 @@
 use std::fmt;
 
-pub trait Truthy {
-    fn is_truthy(&self) -> bool;
-}
+#[cfg(test)]
+mod tests;
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Object {
     Literal(Literal),
 }
 
-impl Truthy for Object {
-    fn is_truthy(&self) -> bool {
+impl Into<bool> for Object {
+    fn into(self) -> bool {
         match self {
-            Self::Literal(l) => l.is_truthy(),
+            Self::Literal(l) => l.into(),
         }
     }
 }
@@ -53,13 +52,13 @@ impl std::convert::From<f64> for Literal {
     }
 }
 
-impl Truthy for Literal {
-    fn is_truthy(&self) -> bool {
+impl Into<bool> for Literal {
+    fn into(self) -> bool {
         match self {
             Self::Nil => false,
-            Self::Bool(b) => *b,
+            Self::Bool(b) => b,
             Self::Str(s) => !s.is_empty(),
-            Self::Number(n) => n.abs() < std::f64::EPSILON,
+            Self::Number(n) => n.abs() > std::f64::EPSILON,
         }
     }
 }

--- a/librlox/src/object/tests/mod.rs
+++ b/librlox/src/object/tests/mod.rs
@@ -1,1 +1,27 @@
+use crate::object::{Literal, Object};
 
+#[test]
+fn bool_literal_object_converts_into_equivalent_primitive_bool() {
+    assert_eq!(true, Object::Literal(Literal::Bool(true)).into());
+    assert_eq!(false, Object::Literal(Literal::Bool(false)).into());
+}
+
+#[test]
+fn number_literal_object_converts_into_equivalent_primitive_bool() {
+    assert_eq!(true, Object::Literal(Literal::Number(5.0)).into());
+    assert_eq!(false, Object::Literal(Literal::Number(0.0)).into());
+}
+
+#[test]
+fn str_literal_object_converts_into_equivalent_primitive_bool() {
+    assert_eq!(
+        true,
+        Object::Literal(Literal::Str("hello".to_string())).into()
+    );
+    assert_eq!(false, Object::Literal(Literal::Str("".to_string())).into());
+}
+
+#[test]
+fn nil_literal_object_converts_into_equivalent_primitive_bool() {
+    assert_eq!(false, Object::Literal(Literal::Nil).into());
+}


### PR DESCRIPTION
# Introduction
This PR removes the `Truthy` trait on the runtime `Object` type in favor of implementing the `std::convert::Into` trait to convert and object to a primitive boolean.

# Linked Issues
resolves #68 
# Dependencies

# Test
- [x] Tested Locally
- [ ] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
