### PR TITLE
Begin implementing scoping to environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,34 @@ A rust implementation of https://craftinginterpreters.com/
 ## Grammars
 
 ```
-expression     = equality ;
+program        = statement* EOF ;
+
+declaration    = varDecl
+               | statement ;
+
+varDecl        = "var" IDENTIFIER ( "=" expression )? ";" ;
+
+statement      = exprStmt
+               | printStmt ;
+
+block          = "{" declaration* "}" ;
+
+exprStmt       = expression ";" ;
+printStmt      = "print" expression ";" ;
+
+
+statement      = exprStmt
+               | printStmt
+               | block ;
+
+expression     = assigment ;
+assignment     = IDENTIFIER "=" equality
+               | equality ;
 equality       = comparison ( ( "!=" | "==" ) comparison )* ;
 comparison     = addition ( ( ">" | ">=" | "<" | "<=" ) addition )* ;
 addition       = multiplication ( ( "-" | "+" ) multiplication )* ;
 multiplication = unary ( ( "/" | "*" ) unary )* ;
 unary          = ( "!" | "-" ) unary | primary ;
-primary        = NUMBER | STRING | "true" | "false" | "nil"
+primary        = NUMBER | STRING | IDENTIFIER | "true" | "false" | "nil"
                | "(" expression ")" ;
 ```

--- a/benches/rlox_bench.rs
+++ b/benches/rlox_bench.rs
@@ -3,6 +3,7 @@ extern crate librlox;
 extern crate parcel;
 use librlox::ast::token::Token;
 use librlox::parser::expression_parser::expression;
+use librlox::parser::statement_parser::statements;
 use librlox::scanner::Scanner;
 
 use parcel::prelude::v1::*;
@@ -33,5 +34,27 @@ fn parse_expr_benchmark(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, scan_tokens_benchmark, parse_expr_benchmark);
+fn parse_statement_benchmark(c: &mut Criterion) {
+    let s = Scanner::new("{ 5 + 5 }".to_string());
+    let token_iter = s.into_iter();
+    let tokens: Vec<Token> = token_iter
+        .map(|tok| match tok {
+            Ok(tok) => tok,
+            Err(e) => panic!("{}", e),
+        })
+        .collect();
+
+    c.bench_function("parse statement", |b| {
+        b.iter(|| {
+            let _expr = statements().parse(&tokens);
+        })
+    });
+}
+
+criterion_group!(
+    benches,
+    scan_tokens_benchmark,
+    parse_expr_benchmark,
+    parse_statement_benchmark
+);
 criterion_main!(benches);

--- a/librlox/src/ast/statement.rs
+++ b/librlox/src/ast/statement.rs
@@ -8,6 +8,7 @@ pub enum Stmt {
     Expression(Expr),
     Print(Expr),
     Declaration(String, Expr),
+    Block(Vec<Stmt>),
 }
 
 impl fmt::Display for Stmt {
@@ -16,6 +17,7 @@ impl fmt::Display for Stmt {
             Self::Expression(e) => write!(f, "(Expression {})", &e),
             Self::Print(e) => write!(f, "(Print {})", &e),
             Self::Declaration(name, e) => write!(f, "(Declaration {} {}", &name, &e),
+            Self::Block(stmts) => write!(f, "(Block {:?})", stmts),
         }
     }
 }

--- a/librlox/src/environment/mod.rs
+++ b/librlox/src/environment/mod.rs
@@ -7,6 +7,7 @@ use std::rc::Rc;
 mod tests;
 
 type SymbolTable = HashMap<String, object::Object>;
+type Parent = Box<Rc<Environment>>;
 
 /// Functions as a symbols table for looking up variables assignments.
 #[derive(Default, Debug)]
@@ -19,6 +20,13 @@ impl Environment {
     pub fn new() -> Rc<Self> {
         Rc::new(Environment {
             parent: None,
+            symbols_table: RefCell::new(SymbolTable::new()),
+        })
+    }
+
+    pub fn from(parent: &Rc<Environment>) -> Rc<Self> {
+        Rc::new(Environment {
+            parent: Some(Box::new(parent.clone())),
             symbols_table: RefCell::new(SymbolTable::new()),
         })
     }
@@ -43,10 +51,4 @@ impl Environment {
     pub fn get(&self, name: &str) -> Option<object::Object> {
         self.symbols_table.borrow().get(name).cloned()
     }
-}
-
-// Wraps an environment for nesting
-#[derive(Default, Debug)]
-struct Parent {
-    parent: Rc<Environment>,
 }

--- a/librlox/src/environment/mod.rs
+++ b/librlox/src/environment/mod.rs
@@ -1,6 +1,7 @@
 use crate::object;
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::rc::Rc;
 
 #[cfg(test)]
 mod tests;
@@ -10,15 +11,19 @@ type SymbolTable = HashMap<String, object::Object>;
 /// Functions as a symbols table for looking up variables assignments.
 #[derive(Default, Debug)]
 pub struct Environment {
+    parent: Option<Parent>,
     symbols_table: RefCell<SymbolTable>,
 }
 
 impl Environment {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new() -> Rc<Self> {
+        Rc::new(Environment {
+            parent: None,
+            symbols_table: RefCell::new(SymbolTable::new()),
+        })
     }
 
-    pub fn assign(&mut self, name: &str, value: object::Object) -> Option<object::Object> {
+    pub fn assign(&self, name: &str, value: object::Object) -> Option<object::Object> {
         let id = name.to_string();
         if None == self.symbols_table.borrow().get(&id) {
             return None;
@@ -27,7 +32,7 @@ impl Environment {
         self.define(&id, value)
     }
 
-    pub fn define(&mut self, name: &str, value: object::Object) -> Option<object::Object> {
+    pub fn define(&self, name: &str, value: object::Object) -> Option<object::Object> {
         self.symbols_table
             .borrow_mut()
             .insert(name.to_string(), value.clone());
@@ -35,7 +40,13 @@ impl Environment {
         Some(value)
     }
 
-    pub fn get(&mut self, name: &str) -> Option<object::Object> {
+    pub fn get(&self, name: &str) -> Option<object::Object> {
         self.symbols_table.borrow().get(name).cloned()
     }
+}
+
+// Wraps an environment for nesting
+#[derive(Default, Debug)]
+struct Parent {
+    parent: Rc<Environment>,
 }

--- a/librlox/src/environment/mod.rs
+++ b/librlox/src/environment/mod.rs
@@ -33,11 +33,11 @@ impl Environment {
 
     pub fn assign(&self, name: &str, value: object::Object) -> Option<object::Object> {
         let id = name.to_string();
-        if None == self.symbols_table.borrow().get(&id) {
-            return None;
+        if self.symbols_table.borrow().contains_key(&id) {
+            self.define(&id, value)
+        } else {
+            None
         }
-
-        self.define(&id, value)
     }
 
     pub fn define(&self, name: &str, value: object::Object) -> Option<object::Object> {

--- a/librlox/src/environment/mod.rs
+++ b/librlox/src/environment/mod.rs
@@ -1,13 +1,16 @@
 use crate::object;
+use std::cell::RefCell;
 use std::collections::HashMap;
 
 #[cfg(test)]
 mod tests;
 
+type SymbolTable = HashMap<String, object::Object>;
+
 /// Functions as a symbols table for looking up variables assignments.
 #[derive(Default, Debug)]
 pub struct Environment {
-    symbols_table: HashMap<String, object::Object>,
+    symbols_table: RefCell<SymbolTable>,
 }
 
 impl Environment {
@@ -17,7 +20,7 @@ impl Environment {
 
     pub fn assign(&mut self, name: &str, value: object::Object) -> Option<object::Object> {
         let id = name.to_string();
-        if None == self.symbols_table.get(&id) {
+        if None == self.symbols_table.borrow().get(&id) {
             return None;
         }
 
@@ -25,12 +28,14 @@ impl Environment {
     }
 
     pub fn define(&mut self, name: &str, value: object::Object) -> Option<object::Object> {
-        self.symbols_table.insert(name.to_string(), value.clone());
+        self.symbols_table
+            .borrow_mut()
+            .insert(name.to_string(), value.clone());
 
         Some(value)
     }
 
-    pub fn get(&mut self, name: &str) -> Option<&object::Object> {
-        self.symbols_table.get(name)
+    pub fn get(&mut self, name: &str) -> Option<object::Object> {
+        self.symbols_table.borrow().get(name).cloned()
     }
 }

--- a/librlox/src/environment/tests/mod.rs
+++ b/librlox/src/environment/tests/mod.rs
@@ -51,3 +51,26 @@ fn environment_should_return_some_if_assign_of_undefined_symbol() {
         Option::Some(obj_bool!(false))
     );
 }
+
+#[test]
+fn new_environment_should_have_no_parent() {
+    let symtable = Environment::new();
+
+    // Subsequent returns previous value
+    match symtable.parent {
+        Some(_) => assert!(false),
+        None => assert!(true),
+    }
+}
+
+#[test]
+fn new_derived_environment_should_have_a_parent() {
+    let parent = Environment::new();
+    let child = Environment::from(&parent);
+
+    // Subsequent returns previous value
+    match child.parent {
+        Some(_) => assert!(true),
+        None => assert!(false),
+    }
+}

--- a/librlox/src/environment/tests/mod.rs
+++ b/librlox/src/environment/tests/mod.rs
@@ -56,7 +56,6 @@ fn environment_should_return_some_if_assign_of_undefined_symbol() {
 fn new_environment_should_have_no_parent() {
     let symtable = Environment::new();
 
-    // Subsequent returns previous value
     match symtable.parent {
         Some(_) => assert!(false),
         None => assert!(true),
@@ -64,13 +63,35 @@ fn new_environment_should_have_no_parent() {
 }
 
 #[test]
-fn new_derived_environment_should_have_a_parent() {
+fn new_child_environment_should_have_a_parent() {
     let parent = Environment::new();
     let child = Environment::from(&parent);
 
-    // Subsequent returns previous value
     match child.parent {
         Some(_) => assert!(true),
         None => assert!(false),
     }
+}
+
+#[test]
+fn child_environment_should_be_able_to_reference_parent_symbols() {
+    let parent = Environment::new();
+    let child = Environment::from(&parent);
+    let key = "test";
+
+    parent.define(&key, obj_bool!(true));
+
+    assert_eq!(child.get(&key), Option::Some(obj_bool!(true)))
+}
+
+#[test]
+fn child_environment_should_be_able_to_assign_symbols_to_parents() {
+    let parent = Environment::new();
+    let child = Environment::from(&parent);
+    let key = "test";
+
+    parent.define(&key, obj_bool!(true));
+    child.assign(&key, obj_bool!(false));
+
+    assert_eq!(child.get(&key), Option::Some(obj_bool!(false)))
 }

--- a/librlox/src/environment/tests/mod.rs
+++ b/librlox/src/environment/tests/mod.rs
@@ -3,7 +3,7 @@ use std::option::Option;
 
 #[test]
 fn environment_should_allow_setting_of_symbols() {
-    let mut symtable = Environment::new();
+    let symtable = Environment::new();
     let key = "test";
 
     // unset var returns None
@@ -20,7 +20,7 @@ fn environment_should_allow_setting_of_symbols() {
 
 #[test]
 fn environment_should_allow_getting_of_symbols() {
-    let mut symtable = Environment::new();
+    let symtable = Environment::new();
     let key = "test";
 
     assert_eq!(
@@ -33,7 +33,7 @@ fn environment_should_allow_getting_of_symbols() {
 
 #[test]
 fn environment_should_return_none_if_assign_of_undefined_symbol() {
-    let mut symtable = Environment::new();
+    let symtable = Environment::new();
 
     // unset var returns None
     assert_eq!(symtable.assign(&"test", obj_bool!(true)), Option::None);
@@ -41,7 +41,7 @@ fn environment_should_return_none_if_assign_of_undefined_symbol() {
 
 #[test]
 fn environment_should_return_some_if_assign_of_undefined_symbol() {
-    let mut symtable = Environment::new();
+    let symtable = Environment::new();
 
     symtable.define(&"test", obj_bool!(true));
 

--- a/librlox/src/environment/tests/mod.rs
+++ b/librlox/src/environment/tests/mod.rs
@@ -28,7 +28,7 @@ fn environment_should_allow_getting_of_symbols() {
         Option::Some(obj_bool!(true))
     );
 
-    assert_eq!(symtable.get(&key), Option::Some(&obj_bool!(true)));
+    assert_eq!(symtable.get(&key), Option::Some(obj_bool!(true)));
 }
 
 #[test]

--- a/librlox/src/interpreter/mod.rs
+++ b/librlox/src/interpreter/mod.rs
@@ -5,6 +5,7 @@ use crate::ast::token;
 use crate::environment::Environment;
 use crate::object::{Literal, Object};
 use std::fmt;
+use std::rc::Rc;
 
 #[cfg(test)]
 mod tests;
@@ -73,7 +74,7 @@ pub type ExprInterpreterResult = Result<Object, ExprInterpreterErr>;
 
 #[derive(Default)]
 pub struct StatefulInterpreter {
-    pub globals: Environment,
+    pub globals: Rc<Environment>,
 }
 
 impl StatefulInterpreter {
@@ -274,11 +275,11 @@ impl StatefulInterpreter {
         Ok(obj)
     }
 
-    fn interpret_variable(&mut self, identifier: token::Token) -> ExprInterpreterResult {
+    fn interpret_variable(&self, identifier: token::Token) -> ExprInterpreterResult {
         let var = identifier.lexeme.unwrap();
 
         match self.globals.get(&var) {
-            Some(v) => Ok(v.to_owned()),
+            Some(v) => Ok(v),
             None => Err(ExprInterpreterErr::UndefinedVariable(var.clone())),
         }
     }

--- a/librlox/src/interpreter/tests/expression/addition.rs
+++ b/librlox/src/interpreter/tests/expression/addition.rs
@@ -1,5 +1,5 @@
 use crate::ast::expression::{AdditionExpr, Expr, MultiplicationExpr};
-use crate::interpreter::InterpreterMut;
+use crate::interpreter::Interpreter;
 use crate::interpreter::StatefulInterpreter;
 
 macro_rules! primary_number {

--- a/librlox/src/interpreter/tests/expression/comparison.rs
+++ b/librlox/src/interpreter/tests/expression/comparison.rs
@@ -1,5 +1,5 @@
 use crate::ast::expression::{ComparisonExpr, Expr, MultiplicationExpr};
-use crate::interpreter::InterpreterMut;
+use crate::interpreter::Interpreter;
 use crate::interpreter::StatefulInterpreter;
 
 macro_rules! primary_number {

--- a/librlox/src/interpreter/tests/expression/equality.rs
+++ b/librlox/src/interpreter/tests/expression/equality.rs
@@ -1,5 +1,5 @@
 use crate::ast::expression::{EqualityExpr, Expr, MultiplicationExpr};
-use crate::interpreter::InterpreterMut;
+use crate::interpreter::Interpreter;
 use crate::interpreter::StatefulInterpreter;
 
 macro_rules! primary_number {

--- a/librlox/src/interpreter/tests/expression/grouping.rs
+++ b/librlox/src/interpreter/tests/expression/grouping.rs
@@ -1,5 +1,5 @@
 use crate::ast::expression::{AdditionExpr, Expr, MultiplicationExpr};
-use crate::interpreter::InterpreterMut;
+use crate::interpreter::Interpreter;
 use crate::interpreter::StatefulInterpreter;
 
 macro_rules! primary_number {

--- a/librlox/src/interpreter/tests/expression/multiplication.rs
+++ b/librlox/src/interpreter/tests/expression/multiplication.rs
@@ -1,6 +1,6 @@
 use crate::ast::expression::{Expr, MultiplicationExpr, UnaryExpr};
 use crate::interpreter::ExprInterpreterErr;
-use crate::interpreter::InterpreterMut;
+use crate::interpreter::Interpreter;
 use crate::interpreter::StatefulInterpreter;
 
 macro_rules! primary_number {

--- a/librlox/src/interpreter/tests/expression/primary.rs
+++ b/librlox/src/interpreter/tests/expression/primary.rs
@@ -1,5 +1,5 @@
 use crate::ast::expression::Expr;
-use crate::interpreter::InterpreterMut;
+use crate::interpreter::Interpreter;
 use crate::interpreter::StatefulInterpreter;
 
 #[test]

--- a/librlox/src/interpreter/tests/expression/unary.rs
+++ b/librlox/src/interpreter/tests/expression/unary.rs
@@ -1,5 +1,5 @@
 use crate::ast::expression::{Expr, UnaryExpr};
-use crate::interpreter::InterpreterMut;
+use crate::interpreter::Interpreter;
 use crate::interpreter::StatefulInterpreter;
 
 #[test]

--- a/librlox/src/interpreter/tests/expression/variable.rs
+++ b/librlox/src/interpreter/tests/expression/variable.rs
@@ -6,8 +6,8 @@ use crate::interpreter::StatefulInterpreter;
 #[test]
 fn declaration_statement_should_set_persistent_global_symbol() {
     let interpreter = StatefulInterpreter::new();
-    interpreter.globals.define(&"a", obj_number!(1.0));
-    interpreter.globals.define(&"b", obj_number!(2.0));
+    interpreter.env.define(&"a", obj_number!(1.0));
+    interpreter.env.define(&"b", obj_number!(2.0));
 
     assert_eq!(
         Ok(()),

--- a/librlox/src/interpreter/tests/expression/variable.rs
+++ b/librlox/src/interpreter/tests/expression/variable.rs
@@ -1,11 +1,11 @@
 use crate::ast::expression::{AdditionExpr, Expr};
 use crate::ast::statement::Stmt;
-use crate::interpreter::InterpreterMut;
+use crate::interpreter::Interpreter;
 use crate::interpreter::StatefulInterpreter;
 
 #[test]
 fn declaration_statement_should_set_persistent_global_symbol() {
-    let mut interpreter = StatefulInterpreter::new();
+    let interpreter = StatefulInterpreter::new();
     interpreter.globals.define(&"a", obj_number!(1.0));
     interpreter.globals.define(&"b", obj_number!(2.0));
 

--- a/librlox/src/interpreter/tests/statement/mod.rs
+++ b/librlox/src/interpreter/tests/statement/mod.rs
@@ -27,6 +27,6 @@ fn declaration_statement_should_set_persistent_global_symbol() {
     interpreter.interpret(vec![stmt]).unwrap();
     assert_eq!(
         Some(obj_bool!(true)),
-        interpreter.globals.get(&"test".to_string())
+        interpreter.env.get(&"test".to_string())
     );
 }

--- a/librlox/src/interpreter/tests/statement/mod.rs
+++ b/librlox/src/interpreter/tests/statement/mod.rs
@@ -26,7 +26,7 @@ fn declaration_statement_should_set_persistent_global_symbol() {
     let mut interpreter = StatefulInterpreter::new();
     interpreter.interpret(vec![stmt]).unwrap();
     assert_eq!(
-        Some(&obj_bool!(true)),
+        Some(obj_bool!(true)),
         interpreter.globals.get(&"test".to_string())
     );
 }

--- a/librlox/src/interpreter/tests/statement/mod.rs
+++ b/librlox/src/interpreter/tests/statement/mod.rs
@@ -30,3 +30,9 @@ fn declaration_statement_should_set_persistent_global_symbol() {
         interpreter.env.get(&"test".to_string())
     );
 }
+
+#[test]
+fn block_statement_should_set_persistent_global_symbol() {
+    let stmts = Stmt::Block(vec![Stmt::Expression(Expr::Primary(obj_bool!(true)))]);
+    assert_eq!(Ok(()), StatefulInterpreter::new().interpret(stmts));
+}

--- a/librlox/src/interpreter/tests/statement/mod.rs
+++ b/librlox/src/interpreter/tests/statement/mod.rs
@@ -1,6 +1,6 @@
 use crate::ast::expression::Expr;
 use crate::ast::statement::Stmt;
-use crate::interpreter::InterpreterMut;
+use crate::interpreter::Interpreter;
 use crate::interpreter::StatefulInterpreter;
 
 #[test]
@@ -23,7 +23,7 @@ fn print_stmt_should_return_ok() {
 #[test]
 fn declaration_statement_should_set_persistent_global_symbol() {
     let stmt = Stmt::Declaration("test".to_string(), Expr::Primary(obj_bool!(true)));
-    let mut interpreter = StatefulInterpreter::new();
+    let interpreter = StatefulInterpreter::new();
     interpreter.interpret(vec![stmt]).unwrap();
     assert_eq!(
         Some(obj_bool!(true)),

--- a/librlox/src/parser/statement_parser.rs
+++ b/librlox/src/parser/statement_parser.rs
@@ -58,8 +58,8 @@ fn declaration_stmt<'a>() -> impl parcel::Parser<'a, &'a [Token], Stmt> {
 #[allow(clippy::redundant_closure)]
 fn block<'a>() -> impl parcel::Parser<'a, &'a [Token], Stmt> {
     right(join(
-        token_type(TokenType::LeftParen),
-        left(join(statements(), token_type(TokenType::RightParen))),
+        token_type(TokenType::LeftBrace),
+        left(join(statements(), token_type(TokenType::RightBrace))),
     ))
     .map(|stmts| Stmt::Block(stmts))
 }

--- a/librlox/src/parser/statement_parser.rs
+++ b/librlox/src/parser/statement_parser.rs
@@ -16,6 +16,7 @@ fn statement<'a>() -> impl parcel::Parser<'a, &'a [Token], Stmt> {
     declaration_stmt()
         .or(|| print_stmt())
         .or(|| expression_stmt())
+        .or(|| block())
 }
 
 #[allow(clippy::redundant_closure)]
@@ -52,4 +53,13 @@ fn declaration_stmt<'a>() -> impl parcel::Parser<'a, &'a [Token], Stmt> {
 
         Stmt::Declaration(id, expr)
     })
+}
+
+#[allow(clippy::redundant_closure)]
+fn block<'a>() -> impl parcel::Parser<'a, &'a [Token], Stmt> {
+    right(join(
+        token_type(TokenType::LeftParen),
+        left(join(statements(), token_type(TokenType::RightParen))),
+    ))
+    .map(|stmts| Stmt::Block(stmts))
 }

--- a/librlox/src/parser/tests/statement_parser.rs
+++ b/librlox/src/parser/tests/statement_parser.rs
@@ -73,11 +73,11 @@ fn parser_can_parse_block_stmt() {
         Option::Some(obj_number!(5.0)),
     );
     let input = vec![
-        Token::new(TokenType::LeftParen, 1, Option::None, Option::None),
+        Token::new(TokenType::LeftBrace, 1, Option::None, Option::None),
         Token::new(TokenType::Print, 1, Option::None, Option::None),
         literal_token.clone(),
         Token::new(TokenType::Semicolon, 1, Option::None, Option::None),
-        Token::new(TokenType::RightParen, 1, Option::None, Option::None),
+        Token::new(TokenType::RightBrace, 1, Option::None, Option::None),
     ];
 
     assert_eq!(

--- a/librlox/src/parser/tests/statement_parser.rs
+++ b/librlox/src/parser/tests/statement_parser.rs
@@ -8,7 +8,7 @@ use parcel::MatchStatus;
 use std::option::Option;
 
 #[test]
-fn test_parser_can_parse_declaration_stmt() {
+fn parser_can_parse_declaration_stmt() {
     let identifier_token = Token::new(
         TokenType::Identifier,
         1,
@@ -36,6 +36,56 @@ fn test_parser_can_parse_declaration_stmt() {
                 "test".to_string(),
                 Expr::Primary(obj_number!(5.0))
             )]
+        ))),
+        statements().parse(&input)
+    );
+}
+
+#[test]
+fn parser_can_parse_print_stmt() {
+    let literal_token = Token::new(
+        TokenType::Number,
+        1,
+        Option::Some("5.0".to_string()),
+        Option::Some(obj_number!(5.0)),
+    );
+    let input = vec![
+        Token::new(TokenType::Print, 1, Option::None, Option::None),
+        literal_token.clone(),
+        Token::new(TokenType::Semicolon, 1, Option::None, Option::None),
+    ];
+
+    assert_eq!(
+        Ok(MatchStatus::Match((
+            &input[3..],
+            vec![Stmt::Print(Expr::Primary(obj_number!(5.0)))]
+        ))),
+        statements().parse(&input)
+    );
+}
+
+#[test]
+fn parser_can_parse_block_stmt() {
+    let literal_token = Token::new(
+        TokenType::Number,
+        1,
+        Option::Some("5.0".to_string()),
+        Option::Some(obj_number!(5.0)),
+    );
+    let input = vec![
+        Token::new(TokenType::LeftParen, 1, Option::None, Option::None),
+        Token::new(TokenType::Print, 1, Option::None, Option::None),
+        literal_token.clone(),
+        Token::new(TokenType::Semicolon, 1, Option::None, Option::None),
+        Token::new(TokenType::RightParen, 1, Option::None, Option::None),
+    ];
+
+    assert_eq!(
+        Ok(MatchStatus::Match((
+            &input[5..],
+            vec![Stmt::Block(vec![Stmt::Print(Expr::Primary(obj_number!(
+                5.0
+            )))])]
         ))),
         statements().parse(&input)
     );

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use std::process;
 extern crate librlox;
 extern crate parcel;
 use librlox::ast::token;
-use librlox::interpreter::InterpreterMut;
+use librlox::interpreter::Interpreter;
 use librlox::interpreter::StatefulInterpreter;
 use librlox::parser::statement_parser::statements;
 use librlox::scanner;


### PR DESCRIPTION
# Introduction
This PR introduces environment scoping by including increasingly nested environments.

```
> var test = 1;
> { var test = 5; print test; } 
5
> print test;
1
> { test = 5; print test; }
5
> print test;
5
>
```

# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
