### PR TITLE
Fix boolean throwing errors at expression evaluation

### DIFF
--- a/librlox/src/scanner/source_scanner.rs
+++ b/librlox/src/scanner/source_scanner.rs
@@ -414,6 +414,33 @@ impl Scanner {
                     );
 
                     return match t.is_reserved_keyword() {
+                        Some(TokenType::True) => (
+                            Ok(Token::new(
+                                TokenType::True,
+                                current.line,
+                                None,
+                                Some(obj_bool!(true)),
+                            )),
+                            current,
+                        ),
+                        Some(TokenType::False) => (
+                            Ok(Token::new(
+                                TokenType::False,
+                                current.line,
+                                None,
+                                Some(obj_bool!(false)),
+                            )),
+                            current,
+                        ),
+                        Some(TokenType::Nil) => (
+                            Ok(Token::new(
+                                TokenType::Nil,
+                                current.line,
+                                None,
+                                Some(obj_nil!()),
+                            )),
+                            current,
+                        ),
                         Some(token_type) => (
                             Ok(Token::new(token_type, current.line, None, None)),
                             current,

--- a/librlox/src/scanner/tests/token_lexing/helpers.rs
+++ b/librlox/src/scanner/tests/token_lexing/helpers.rs
@@ -36,7 +36,11 @@ pub fn compare_single_token_source_with_literal_helper(
         LexResult::Ok(Token {
             token_type: expected_token_type,
             line: 1,
-            lexeme: Some(lexeme.trim().to_string()),
+            lexeme: if lexeme.len() > 0 {
+                Some(lexeme.trim().to_string())
+            } else {
+                None
+            },
             object: obj,
         })
     );

--- a/librlox/src/scanner/tests/token_lexing/identifiers.rs
+++ b/librlox/src/scanner/tests/token_lexing/identifiers.rs
@@ -36,13 +36,31 @@ fn scan_tokens_should_lex_reserved_keywords() {
     compare_single_token_source_helper("super", TokenType::Super);
     compare_single_token_source_helper("class", TokenType::Class);
     compare_single_token_source_helper("this", TokenType::This);
-    compare_single_token_source_helper("nil", TokenType::Nil);
-    compare_single_token_source_helper("true", TokenType::True);
-    compare_single_token_source_helper("false", TokenType::False);
     compare_single_token_source_helper("var", TokenType::Var);
     compare_single_token_source_helper("fun", TokenType::Fun);
     compare_single_token_source_helper("while", TokenType::While);
     compare_single_token_source_helper("for", TokenType::For);
     compare_single_token_source_helper("if", TokenType::If);
     compare_single_token_source_helper("else", TokenType::Else);
+}
+#[test]
+fn scan_tokens_should_lex_runtime_object_keywords() {
+    compare_single_token_source_with_literal_helper(
+        "true",
+        "",
+        Option::Some(obj_bool!(true)),
+        TokenType::True,
+    );
+    compare_single_token_source_with_literal_helper(
+        "false",
+        "",
+        Option::Some(obj_bool!(false)),
+        TokenType::False,
+    );
+    compare_single_token_source_with_literal_helper(
+        "nil",
+        "",
+        Option::Some(obj_nil!()),
+        TokenType::Nil,
+    );
 }


### PR DESCRIPTION
# Introduction
This PR fixes an error where boolean and nil tokens were not having a corresponding runtime object attached to their token when lexed causing parsing to fail when the corresponding object was referenced and handed off to the interpreter.

# Linked Issues
resolves #73 
# Dependencies

# Test
- [x] Tested Locally

```
> print true;
true
> print false;
false
> print nil;
nil
```

- [ ] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
