### PR TITLE
Cleanup expr tests names and update to use macros

### DIFF
--- a/src/parser/tests/expression_parser.rs
+++ b/src/parser/tests/expression_parser.rs
@@ -31,33 +31,32 @@ macro_rules! token_from_tt {
 }
 
 #[test]
-fn validate_parser_should_parse_assignment_expression() {
-    let op_token = Token::new(TokenType::Equal, 1, Option::None, Option::None);
-    let id_token = Token::new(
-        TokenType::Identifier,
-        1,
-        Option::Some("test".to_string()),
-        Option::None,
-    );
-    let literal_token = Token::new(
-        TokenType::Number,
-        1,
-        Option::Some("1.0".to_string()),
-        Option::Some(obj_number!(1.0)),
-    );
-    let seed_vec = vec![id_token.clone(), op_token.clone(), literal_token.clone()];
+fn parser_should_parse_assignment_expression() {
+    let input = vec![
+        token_from_tt!(TokenType::Identifier, "test"),
+        token_from_tt!(TokenType::Equal),
+        token_from_tt!(TokenType::Number, "1.0", obj_number!(1.0)),
+    ];
 
     assert_eq!(
         Ok(MatchStatus::Match((
-            &seed_vec[3..],
-            Expr::Assignment(id_token.clone(), Box::new(Expr::Primary(obj_number!(1.0))))
+            &input[3..],
+            Expr::Assignment(
+                Token::new(
+                    TokenType::Identifier,
+                    1,
+                    Option::Some("test".to_string()),
+                    Option::None
+                ),
+                Box::new(Expr::Primary(obj_number!(1.0)))
+            )
         ))),
-        expression().parse(&seed_vec)
+        expression().parse(&input)
     );
 }
 
 #[test]
-fn validate_parser_should_parse_logical_or() {
+fn parser_should_parse_logical_or() {
     let input = vec![
         token_from_tt!(TokenType::False, "false", obj_bool!(false)),
         token_from_tt!(TokenType::Or),
@@ -77,7 +76,7 @@ fn validate_parser_should_parse_logical_or() {
 }
 
 #[test]
-fn validate_parser_should_parse_multiple_logical_or() {
+fn parser_should_parse_multiple_logical_or() {
     let input = vec![
         token_from_tt!(TokenType::False, "false", obj_bool!(false)),
         token_from_tt!(TokenType::Or),
@@ -102,7 +101,7 @@ fn validate_parser_should_parse_multiple_logical_or() {
 }
 
 #[test]
-fn validate_parser_should_parse_logical_and() {
+fn parser_should_parse_logical_and() {
     let input = vec![
         token_from_tt!(TokenType::False, "false", obj_bool!(false)),
         token_from_tt!(TokenType::And),
@@ -122,7 +121,7 @@ fn validate_parser_should_parse_logical_and() {
 }
 
 #[test]
-fn validate_parser_should_parse_multiple_logical_and() {
+fn parser_should_parse_multiple_logical_and() {
     let input = vec![
         token_from_tt!(TokenType::False, "false", obj_bool!(false)),
         token_from_tt!(TokenType::And),
@@ -147,52 +146,38 @@ fn validate_parser_should_parse_multiple_logical_and() {
 }
 
 #[test]
-fn validate_parser_should_parse_equality_expression() {
-    let op_token = Token::new(TokenType::EqualEqual, 1, Option::None, Option::None);
-    let literal_token = Token::new(
-        TokenType::Number,
-        1,
-        Option::Some("1.0".to_string()),
-        Option::Some(obj_number!(1.0)),
-    );
-    let seed_vec = vec![
-        literal_token.clone(),
-        op_token.clone(),
-        literal_token.clone(),
+fn parser_should_parse_equality_expression() {
+    let input = vec![
+        token_from_tt!(TokenType::Number, "1.0", obj_number!(1.0)),
+        token_from_tt!(TokenType::EqualEqual),
+        token_from_tt!(TokenType::Number, "1.0", obj_number!(1.0)),
     ];
 
     assert_eq!(
         Ok(MatchStatus::Match((
-            &seed_vec[3..],
+            &input[3..],
             Expr::Equality(EqualityExpr::Equal(
                 Box::new(Expr::Primary(obj_number!(1.0))),
                 Box::new(Expr::Primary(obj_number!(1.0)))
             ))
         ))),
-        expression().parse(&seed_vec)
+        expression().parse(&input)
     );
 }
 
 #[test]
-fn validate_parser_should_parse_many_equality_expression() {
-    let op_token = Token::new(TokenType::EqualEqual, 1, Option::None, Option::None);
-    let literal_token = Token::new(
-        TokenType::Number,
-        1,
-        Option::Some("1.0".to_string()),
-        Option::Some(obj_number!(1.0)),
-    );
-    let seed_vec = vec![
-        literal_token.clone(),
-        op_token.clone(),
-        literal_token.clone(),
-        op_token.clone(),
-        literal_token.clone(),
+fn parser_should_parse_many_equality_expression() {
+    let input = vec![
+        token_from_tt!(TokenType::Number, "1.0", obj_number!(1.0)),
+        token_from_tt!(TokenType::EqualEqual),
+        token_from_tt!(TokenType::Number, "1.0", obj_number!(1.0)),
+        token_from_tt!(TokenType::EqualEqual),
+        token_from_tt!(TokenType::Number, "1.0", obj_number!(1.0)),
     ];
 
     assert_eq!(
         Ok(MatchStatus::Match((
-            &seed_vec[5..],
+            &input[5..],
             Expr::Equality(EqualityExpr::Equal(
                 Box::new(Expr::Primary(obj_number!(1.0))),
                 Box::new(Expr::Equality(EqualityExpr::Equal(
@@ -201,57 +186,43 @@ fn validate_parser_should_parse_many_equality_expression() {
                 )))
             ))
         ))),
-        expression().parse(&seed_vec)
+        expression().parse(&input)
     );
 }
 
 #[test]
-fn validate_parser_should_parse_comparison_expression() {
-    let op_token = Token::new(TokenType::GreaterEqual, 1, Option::None, Option::None);
-    let literal_token = Token::new(
-        TokenType::Number,
-        1,
-        Option::Some("1.0".to_string()),
-        Option::Some(obj_number!(1.0)),
-    );
-    let seed_vec = vec![
-        literal_token.clone(),
-        op_token.clone(),
-        literal_token.clone(),
+fn parser_should_parse_comparison_expression() {
+    let input = vec![
+        token_from_tt!(TokenType::Number, "1.0", obj_number!(1.0)),
+        token_from_tt!(TokenType::GreaterEqual),
+        token_from_tt!(TokenType::Number, "1.0", obj_number!(1.0)),
     ];
 
     assert_eq!(
         Ok(MatchStatus::Match((
-            &seed_vec[3..],
+            &input[3..],
             Expr::Comparison(ComparisonExpr::GreaterEqual(
                 Box::new(Expr::Primary(obj_number!(1.0))),
                 Box::new(Expr::Primary(obj_number!(1.0)))
             ))
         ))),
-        expression().parse(&seed_vec)
+        expression().parse(&input)
     );
 }
 
 #[test]
-fn validate_parser_should_parse_many_comparison_expression() {
-    let op_token = Token::new(TokenType::GreaterEqual, 1, Option::None, Option::None);
-    let literal_token = Token::new(
-        TokenType::Number,
-        1,
-        Option::Some("1.0".to_string()),
-        Option::Some(obj_number!(1.0)),
-    );
-    let seed_vec = vec![
-        literal_token.clone(),
-        op_token.clone(),
-        literal_token.clone(),
-        op_token.clone(),
-        literal_token.clone(),
+fn parser_should_parse_many_comparison_expression() {
+    let input = vec![
+        token_from_tt!(TokenType::Number, "1.0", obj_number!(1.0)),
+        token_from_tt!(TokenType::GreaterEqual),
+        token_from_tt!(TokenType::Number, "1.0", obj_number!(1.0)),
+        token_from_tt!(TokenType::GreaterEqual),
+        token_from_tt!(TokenType::Number, "1.0", obj_number!(1.0)),
     ];
 
     assert_eq!(
         Ok(MatchStatus::Match((
-            &seed_vec[5..],
+            &input[5..],
             Expr::Comparison(ComparisonExpr::GreaterEqual(
                 Box::new(Expr::Primary(obj_number!(1.0))),
                 Box::new(Expr::Comparison(ComparisonExpr::GreaterEqual(
@@ -260,57 +231,43 @@ fn validate_parser_should_parse_many_comparison_expression() {
                 )))
             ))
         ))),
-        expression().parse(&seed_vec)
+        expression().parse(&input)
     );
 }
 
 #[test]
-fn validate_parser_should_parse_addition_expression() {
-    let op_token = Token::new(TokenType::Plus, 1, Option::None, Option::None);
-    let literal_token = Token::new(
-        TokenType::Number,
-        1,
-        Option::Some("1.0".to_string()),
-        Option::Some(obj_number!(1.0)),
-    );
-    let seed_vec = vec![
-        literal_token.clone(),
-        op_token.clone(),
-        literal_token.clone(),
+fn parser_should_parse_addition_expression() {
+    let input = vec![
+        token_from_tt!(TokenType::Number, "1.0", obj_number!(1.0)),
+        token_from_tt!(TokenType::Plus),
+        token_from_tt!(TokenType::Number, "1.0", obj_number!(1.0)),
     ];
 
     assert_eq!(
         Ok(MatchStatus::Match((
-            &seed_vec[3..],
+            &input[3..],
             Expr::Addition(AdditionExpr::Add(
                 Box::new(Expr::Primary(obj_number!(1.0))),
                 Box::new(Expr::Primary(obj_number!(1.0)))
             ))
         ))),
-        expression().parse(&seed_vec)
+        expression().parse(&input)
     );
 }
 
 #[test]
-fn validate_parser_should_parse_many_addition_expression() {
-    let op_token = Token::new(TokenType::Plus, 1, Option::None, Option::None);
-    let literal_token = Token::new(
-        TokenType::Number,
-        1,
-        Option::Some("1.0".to_string()),
-        Option::Some(obj_number!(1.0)),
-    );
-    let seed_vec = vec![
-        literal_token.clone(),
-        op_token.clone(),
-        literal_token.clone(),
-        op_token.clone(),
-        literal_token.clone(),
+fn parser_should_parse_many_addition_expression() {
+    let input = vec![
+        token_from_tt!(TokenType::Number, "1.0", obj_number!(1.0)),
+        token_from_tt!(TokenType::Plus),
+        token_from_tt!(TokenType::Number, "1.0", obj_number!(1.0)),
+        token_from_tt!(TokenType::Plus),
+        token_from_tt!(TokenType::Number, "1.0", obj_number!(1.0)),
     ];
 
     assert_eq!(
         Ok(MatchStatus::Match((
-            &seed_vec[5..],
+            &input[5..],
             Expr::Addition(AdditionExpr::Add(
                 Box::new(Expr::Primary(obj_number!(1.0))),
                 Box::new(Expr::Addition(AdditionExpr::Add(
@@ -319,57 +276,43 @@ fn validate_parser_should_parse_many_addition_expression() {
                 )))
             ))
         ))),
-        expression().parse(&seed_vec)
+        expression().parse(&input)
     );
 }
 
 #[test]
-fn validate_parser_should_parse_multiplication_expression() {
-    let op_token = Token::new(TokenType::Star, 1, Option::None, Option::None);
-    let literal_token = Token::new(
-        TokenType::Number,
-        1,
-        Option::Some("1.0".to_string()),
-        Option::Some(obj_number!(1.0)),
-    );
-    let seed_vec = vec![
-        literal_token.clone(),
-        op_token.clone(),
-        literal_token.clone(),
+fn parser_should_parse_multiplication_expression() {
+    let input = vec![
+        token_from_tt!(TokenType::Number, "1.0", obj_number!(1.0)),
+        token_from_tt!(TokenType::Star),
+        token_from_tt!(TokenType::Number, "1.0", obj_number!(1.0)),
     ];
 
     assert_eq!(
         Ok(MatchStatus::Match((
-            &seed_vec[3..],
+            &input[3..],
             Expr::Multiplication(MultiplicationExpr::Multiply(
                 Box::new(Expr::Primary(obj_number!(1.0))),
                 Box::new(Expr::Primary(obj_number!(1.0)))
             ))
         ))),
-        expression().parse(&seed_vec)
+        expression().parse(&input)
     );
 }
 
 #[test]
-fn validate_parser_should_parse_many_multiplication_expression() {
-    let op_token = Token::new(TokenType::Star, 1, Option::None, Option::None);
-    let literal_token = Token::new(
-        TokenType::Number,
-        1,
-        Option::Some("1.0".to_string()),
-        Option::Some(obj_number!(1.0)),
-    );
-    let seed_vec = vec![
-        literal_token.clone(),
-        op_token.clone(),
-        literal_token.clone(),
-        op_token.clone(),
-        literal_token.clone(),
+fn parser_should_parse_many_multiplication_expression() {
+    let input = vec![
+        token_from_tt!(TokenType::Number, "1.0", obj_number!(1.0)),
+        token_from_tt!(TokenType::Star),
+        token_from_tt!(TokenType::Number, "1.0", obj_number!(1.0)),
+        token_from_tt!(TokenType::Star),
+        token_from_tt!(TokenType::Number, "1.0", obj_number!(1.0)),
     ];
 
     assert_eq!(
         Ok(MatchStatus::Match((
-            &seed_vec[5..],
+            &input[5..],
             Expr::Multiplication(MultiplicationExpr::Multiply(
                 Box::new(Expr::Primary(obj_number!(1.0))),
                 Box::new(Expr::Multiplication(MultiplicationExpr::Multiply(
@@ -378,32 +321,28 @@ fn validate_parser_should_parse_many_multiplication_expression() {
                 )))
             ))
         ))),
-        expression().parse(&seed_vec)
+        expression().parse(&input)
     );
 }
 
 #[test]
-fn validate_parser_should_parse_unary_expression() {
-    let op_token = Token::new(TokenType::Bang, 1, Option::None, Option::None);
-    let literal_token = Token::new(
-        TokenType::Number,
-        1,
-        Option::Some("1.0".to_string()),
-        Option::Some(obj_number!(1.0)),
-    );
-    let seed_vec = vec![op_token.clone(), literal_token.clone()];
+fn parser_should_parse_unary_expression() {
+    let input = vec![
+        token_from_tt!(TokenType::Bang),
+        token_from_tt!(TokenType::Number, "1.0", obj_number!(1.0)),
+    ];
 
     assert_eq!(
         Ok(MatchStatus::Match((
-            &seed_vec[2..],
+            &input[2..],
             Expr::Unary(UnaryExpr::Bang(Box::new(Expr::Primary(obj_number!(1.0)))))
         ))),
-        expression().parse(&seed_vec)
+        expression().parse(&input)
     );
 }
 
 #[test]
-fn validate_parser_should_parse_primary_expression() {
+fn parser_should_parse_primary_expression() {
     match_literal_helper(Token::new(
         TokenType::Number,
         1,
@@ -413,44 +352,32 @@ fn validate_parser_should_parse_primary_expression() {
 }
 
 #[test]
-fn validate_parser_should_parse_grouping_expression() {
-    let literal_token = Token::new(
-        TokenType::Number,
-        1,
-        Option::Some("1.0".to_string()),
-        Option::Some(obj_number!(1.0)),
-    );
-    let seed_vec = vec![
-        Token::new(TokenType::LeftParen, 1, Option::None, Option::None),
-        literal_token.clone(),
-        Token::new(TokenType::RightParen, 1, Option::None, Option::None),
+fn parser_should_parse_grouping_expression() {
+    let input = vec![
+        token_from_tt!(TokenType::LeftParen),
+        token_from_tt!(TokenType::Number, "1.0", obj_number!(1.0)),
+        token_from_tt!(TokenType::RightParen),
     ];
 
     assert_eq!(
         Ok(MatchStatus::Match((
-            &seed_vec[3..],
+            &input[3..],
             Expr::Grouping(Box::new(Expr::Primary(obj_number!(1.0))))
         ))),
-        expression().parse(&seed_vec)
+        expression().parse(&input)
     );
 }
 
 #[test]
-fn validate_parser_should_throw_error_on_invalid_expression() {
-    let literal_token = Token::new(
-        TokenType::Number,
-        1,
-        Option::Some("1.0".to_string()),
-        Option::Some(obj_number!(1.0)),
-    );
-    let seed_vec = vec![
-        Token::new(TokenType::LeftParen, 1, Option::None, Option::None),
-        literal_token.clone(),
-        Token::new(TokenType::Semicolon, 1, Option::None, Option::None),
+fn parser_should_throw_error_on_invalid_expression() {
+    let input = vec![
+        token_from_tt!(TokenType::LeftParen),
+        token_from_tt!(TokenType::Number, "1.0", obj_number!(1.0)),
+        token_from_tt!(TokenType::Semicolon),
     ];
 
     assert_eq!(
-        Ok(MatchStatus::NoMatch(&seed_vec[..])),
-        expression().parse(&seed_vec)
+        Ok(MatchStatus::NoMatch(&input[..])),
+        expression().parse(&input)
     );
 }

--- a/src/parser/tests/expression_parser.rs
+++ b/src/parser/tests/expression_parser.rs
@@ -6,18 +6,6 @@ use crate::ast::token::{Token, TokenType};
 use crate::parser::expression_parser::expression;
 use parcel::*;
 
-fn match_literal_helper(token: Token) {
-    let seed_vec = vec![token.clone()];
-
-    assert_eq!(
-        Ok(MatchStatus::Match((
-            &seed_vec[1..],
-            Expr::Primary(token.object.unwrap())
-        ))),
-        expression().parse(&seed_vec)
-    );
-}
-
 macro_rules! token_from_tt {
     ($tt:expr) => {
         $crate::ast::token::Token::new($tt, 1, Option::None, Option::None)
@@ -343,12 +331,15 @@ fn parser_should_parse_unary_expression() {
 
 #[test]
 fn parser_should_parse_primary_expression() {
-    match_literal_helper(Token::new(
-        TokenType::Number,
-        1,
-        Option::Some("1.0".to_string()),
-        Option::Some(obj_number!(1.0)),
-    ))
+    let input = vec![token_from_tt!(TokenType::Number, "1.0", obj_number!(1.0))];
+
+    assert_eq!(
+        Ok(MatchStatus::Match((
+            &input[1..],
+            Expr::Primary(obj_number!(1.0))
+        ))),
+        expression().parse(&input)
+    );
 }
 
 #[test]


### PR DESCRIPTION
# Introduction
This PR updates expression test names to no longer have the redundant validate prefix as well as updates all test inputs to use the macros for token generation.

# Linked Issues
resolves #54 

# Dependencies

# Test
- [x] Tested Locally
- [ ] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
