### PR TITLE
Mount the devcontainer's target dir in a tmpfs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,6 +20,9 @@
 		"lldb.adapterType": "bundled",
 		"lldb.executable": "/usr/bin/lldb"
 	},
+	"mounts": [
+		"target=${containerWorkspaceFolder}/target,type=tmpfs"
+	],
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
 	// Uncomment the next line to run commands after the container is created.


### PR DESCRIPTION
# Introduction
This PR adds a tmpfs mount for the target directory in the devcontainer workspace to both improve compile time, and save on disk wear and tear within the devcontainer. This works under the assumption that users have ~500MB of RAM that can be dedicated solely to build artifacts in the devcontainer.

# Linked Issues
resolves #92 
# Dependencies

# Test
- [ ] Tested Locally
- [ ] Documented

# Review
- [ ] Ready for review
- [ ] Ready to merge

# Deployment
