### PR TITLE
Fix bug where function calls in a loop cause the loop to break

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,83 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'rlox'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=rlox"
+                ],
+                "filter": {
+                    "name": "rlox",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug executable 'rlox'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=rlox",
+                    "--package=rlox"
+                ],
+                "filter": {
+                    "name": "rlox",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in executable 'rlox'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bin=rlox",
+                    "--package=rlox"
+                ],
+                "filter": {
+                    "name": "rlox",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug benchmark 'rlox_bench'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bench=rlox_bench",
+                    "--package=rlox"
+                ],
+                "filter": {
+                    "name": "rlox_bench",
+                    "kind": "bench"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/examples/thrice.lox
+++ b/examples/thrice.lox
@@ -1,0 +1,9 @@
+fun thrice(fn) {
+  for (var i = 1; i <= 3; i = i + 1) {
+    fn(i);
+  }
+}
+
+thrice(fun (a) {
+  print a;
+});

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -413,15 +413,9 @@ impl Interpreter<Box<Stmt>, Option<Object>> for StatefulInterpreter {
 
 impl StatefulInterpreter {
     fn interpret_expression_stmt(&self, expr: Expr) -> StmtInterpreterResult {
-        match expr {
-            e @ Expr::Call(_, _) => match self.interpret(e) {
-                Ok(rv) => Ok(Some(rv)),
-                Err(err) => Err(StmtInterpreterErr::Expression(err)),
-            },
-            e => match self.interpret(e) {
-                Ok(_) => Ok(None),
-                Err(err) => Err(StmtInterpreterErr::Expression(err)),
-            },
+        match self.interpret(expr) {
+            Ok(_) => Ok(None),
+            Err(err) => Err(StmtInterpreterErr::Expression(err)),
         }
     }
 

--- a/src/interpreter/tests/expression/call.rs
+++ b/src/interpreter/tests/expression/call.rs
@@ -19,7 +19,7 @@ fn should_return_ok_on_success() {
         .define(&"a", obj_call!(Box::new(functions::Callable::Func(f))));
 
     assert_eq!(
-        Ok(Some(obj_nil!())),
+        Ok(None),
         interpreter.interpret(vec![Stmt::Expression(Expr::Call(
             Box::new(Expr::Variable(tok_identifier!("a"))),
             vec![]

--- a/src/interpreter/tests/expression/lambda.rs
+++ b/src/interpreter/tests/expression/lambda.rs
@@ -6,7 +6,7 @@ use crate::interpreter::{ExprInterpreterErr, StatefulInterpreter, StmtInterprete
 #[test]
 fn should_return_a_value_when_specified() {
     let block = Stmt::Block(vec![Stmt::Return(Expr::Primary(obj_bool!(true)))]);
-    let input = vec![Stmt::Expression(Expr::Call(
+    let input = vec![Stmt::Return(Expr::Call(
         Box::new(Expr::Lambda(vec![], Box::new(block))),
         vec![],
     ))];

--- a/src/interpreter/tests/statement/mod.rs
+++ b/src/interpreter/tests/statement/mod.rs
@@ -85,7 +85,7 @@ fn function_call_should_return_a_value_when_specified() {
     let block = Stmt::Block(vec![Stmt::Return(Expr::Primary(obj_bool!(true)))]);
     let input = vec![
         Stmt::Function("test".to_string(), vec![], Box::new(block)),
-        Stmt::Expression(Expr::Call(
+        Stmt::Return(Expr::Call(
             Box::new(Expr::Variable(Token::new(
                 TokenType::Identifier,
                 1,


### PR DESCRIPTION
# Introduction
This PR fixes a bug caused by functions breaking a loop when returning. This was due to expression statements implicitly returning a value rather than returning the unit type signifying that a return should be passed up the chain.

This was identified by attempting to run the following script

```
fun thrice(fn) {
  for (var i = 1; i <= 3; i = i + 1) {
    fn(i);
  }
}

thrice(fun (a) {
  print a;
});
```

Which, before the fix, yielded the following result.

```
vscode@b114b5a116c7:/workspaces/rlox$ cargo run examples/thrice.lox 
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
     Running `target/debug/rlox examples/thrice.lox`
1
```

However after updating the expression statement interpreter to return a unit type response, now correctly yields the following response.

```
vscode@b114b5a116c7:/workspaces/rlox$ cargo run examples/thrice.lox 
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
     Running `target/debug/rlox examples/thrice.lox`
1
2
3
```

Additionally, tests have been added to catch for this case.

# Linked Issues
resolves #96 
# Dependencies

# Test
- [x] Tested Locally
- [ ] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
