### PR TITLE
Implement From trait for StatefulInterpreter.

### DIFF
--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -86,9 +86,10 @@ impl StatefulInterpreter {
             env: Environment::from(&glbls),
         }
     }
+}
 
-    /// from generates an interpreter from a pre-existing environment.
-    pub fn from(env: Rc<Environment>) -> StatefulInterpreter {
+impl From<Rc<Environment>> for StatefulInterpreter {
+    fn from(env: Rc<Environment>) -> StatefulInterpreter {
         let mut si = StatefulInterpreter::new();
         si.env = env;
         si


### PR DESCRIPTION
# Introduction
This replaces the from method on `StatefulInterpreter` with a method that implements the `From<Rc<Enviroment>>` trait.


# Linked Issues
resolves #87 

# Dependencies

# Test
- [x] Tested Locally
- [ ] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
