### PR TITLE
Add Identfier Type

### DIFF
--- a/src/analyzer/scope/tests/mod.rs
+++ b/src/analyzer/scope/tests/mod.rs
@@ -20,7 +20,7 @@ fn print_stmt_should_return_self() {
 #[test]
 fn declaration_statement_should_return_self() {
     let stmts = vec![Stmt::Declaration(
-        "test".to_string(),
+        identifier_id!("test"),
         Expr::Primary(obj_bool!(true)),
     )];
 
@@ -46,7 +46,11 @@ fn block_statement_should_return_self() {
 #[test]
 fn function_declaration_statement_should_return_self() {
     let block = Stmt::Block(vec![Stmt::Expression(Expr::Primary(obj_bool!(true)))]);
-    let stmts = vec![Stmt::Function("test".to_string(), vec![], Box::new(block))];
+    let stmts = vec![Stmt::Function(
+        identifier_id!("test"),
+        vec![],
+        Box::new(block),
+    )];
 
     assert_eq!(Ok(stmts.clone()), ScopeAnalyzer::new().analyze(stmts));
 }
@@ -56,11 +60,11 @@ fn if_statement_should_return_self() {
     let stmts = vec![Stmt::If(
         Expr::Primary(obj_bool!(true)),
         Box::new(Stmt::Declaration(
-            "test".to_string(),
+            identifier_id!("test"),
             Expr::Primary(obj_bool!(true)),
         )),
         Option::Some(Box::new(Stmt::Declaration(
-            "test".to_string(),
+            identifier_id!("test"),
             Expr::Primary(obj_bool!(false)),
         ))),
     )];
@@ -73,7 +77,7 @@ fn while_statement_should_return_self() {
     let stmts = vec![Stmt::While(
         Expr::Primary(obj_bool!(false)),
         Box::new(Stmt::Declaration(
-            "test".to_string(),
+            identifier_id!("test"),
             Expr::Primary(obj_bool!(true)),
         )),
     )];

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 pub mod token;
 
+#[macro_use]
 pub mod expression;
 pub mod statement;
 

--- a/src/ast/statement.rs
+++ b/src/ast/statement.rs
@@ -1,5 +1,4 @@
-use crate::ast::expression::Expr;
-use crate::ast::token;
+use crate::ast::expression::{Expr, Identifier};
 use std::fmt;
 
 /// Represents, and encapsulates statement types possiblepossible in
@@ -10,8 +9,8 @@ pub enum Stmt {
     If(Expr, Box<Stmt>, Option<Box<Stmt>>),
     While(Expr, Box<Stmt>),
     Print(Expr),
-    Function(String, Vec<token::Token>, Box<Stmt>),
-    Declaration(String, Expr),
+    Function(Identifier, Vec<Identifier>, Box<Stmt>),
+    Declaration(Identifier, Expr),
     Return(Expr),
     Block(Vec<Stmt>),
 }

--- a/src/ast/token/mod.rs
+++ b/src/ast/token/mod.rs
@@ -75,24 +75,3 @@ impl fmt::Display for Token {
         }
     }
 }
-
-#[allow(unused_macros)]
-macro_rules! tok_identifier {
-    ($id:expr) => {
-        $crate::ast::token::Token {
-            token_type: $crate::ast::token::TokenType::Identifier,
-            line: 1,
-            lexeme: Option::Some($id.to_string()),
-            object: Option::None,
-        }
-    };
-
-    ($line:literal, $id:expr) => {
-        $crate::ast::token::Token {
-            token_type: $crate::ast::token::TokenType::Identifier,
-            line: $line,
-            lexeme: Option::Some($id.to_string()),
-            object: Option::None,
-        }
-    };
-}

--- a/src/ast/token/token.rs
+++ b/src/ast/token/token.rs
@@ -72,24 +72,3 @@ impl fmt::Display for Token {
         }
     }
 }
-
-#[allow(unused_macros)]
-macro_rules! tok_identifier {
-    ($id:expr) => {
-        $crate::ast::token::Token {
-            token_type: $crate::ast::token::TokenType::Identifier,
-            line: 1,
-            lexeme: Option::Some($id.to_string()),
-            object: Option::None,
-        }
-    };
-
-    ($line:literal, $id:expr) => {
-        $crate::ast::token::Token {
-            token_type: $crate::ast::token::TokenType::Identifier,
-            line: $line,
-            lexeme: Option::Some($id.to_string()),
-            object: Option::None,
-        }
-    };
-}

--- a/src/environment/mod.rs
+++ b/src/environment/mod.rs
@@ -1,3 +1,4 @@
+use crate::ast::expression::Identifier;
 use crate::object;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -6,7 +7,7 @@ use std::rc::Rc;
 #[cfg(test)]
 mod tests;
 
-type SymbolTable = HashMap<String, object::Object>;
+type SymbolTable = HashMap<Identifier, object::Object>;
 type Parent = Box<Rc<Environment>>;
 
 /// Functions as a symbols table for looking up variables assignments.
@@ -31,8 +32,8 @@ impl Environment {
         })
     }
 
-    pub fn assign(&self, name: &str, value: object::Object) -> Option<object::Object> {
-        let id = name.to_string();
+    pub fn assign(&self, name: &Identifier, value: object::Object) -> Option<object::Object> {
+        let id = name;
         let has_key = self.symbols_table.borrow().contains_key(&id);
         match (has_key, self.parent.as_ref()) {
             (true, _) => self.define(&id, value),
@@ -41,15 +42,15 @@ impl Environment {
         }
     }
 
-    pub fn define(&self, name: &str, value: object::Object) -> Option<object::Object> {
+    pub fn define(&self, name: &Identifier, value: object::Object) -> Option<object::Object> {
         self.symbols_table
             .borrow_mut()
-            .insert(name.to_string(), value.clone());
+            .insert(name.clone(), value.clone());
 
         Some(value)
     }
 
-    pub fn get(&self, name: &str) -> Option<object::Object> {
+    pub fn get(&self, name: &Identifier) -> Option<object::Object> {
         let val = self.symbols_table.borrow().get(name).cloned();
         match (val, self.parent.as_ref()) {
             (Some(v), _) => Some(v),

--- a/src/environment/tests/mod.rs
+++ b/src/environment/tests/mod.rs
@@ -4,7 +4,7 @@ use std::option::Option;
 #[test]
 fn environment_should_allow_setting_of_symbols() {
     let symtable = Environment::new();
-    let key = "test";
+    let key = identifier_id!("test");
 
     // unset var returns None
     assert_eq!(
@@ -21,7 +21,7 @@ fn environment_should_allow_setting_of_symbols() {
 #[test]
 fn environment_should_allow_getting_of_symbols() {
     let symtable = Environment::new();
-    let key = "test";
+    let key = identifier_id!("key");
 
     assert_eq!(
         symtable.define(&key, obj_bool!(true)),
@@ -34,20 +34,22 @@ fn environment_should_allow_getting_of_symbols() {
 #[test]
 fn environment_should_return_none_if_assign_of_undefined_symbol() {
     let symtable = Environment::new();
+    let key = identifier_id!("test");
 
     // unset var returns None
-    assert_eq!(symtable.assign(&"test", obj_bool!(true)), Option::None);
+    assert_eq!(symtable.assign(&key, obj_bool!(true)), Option::None);
 }
 
 #[test]
 fn environment_should_return_some_if_assign_of_undefined_symbol() {
     let symtable = Environment::new();
+    let key = identifier_id!("test");
 
-    symtable.define(&"test", obj_bool!(true));
+    symtable.define(&key, obj_bool!(true));
 
     // Subsequent returns previous value
     assert_eq!(
-        symtable.assign(&"test", obj_bool!(false)),
+        symtable.assign(&key, obj_bool!(false)),
         Option::Some(obj_bool!(false))
     );
 }
@@ -77,7 +79,7 @@ fn new_child_environment_should_have_a_parent() {
 fn child_environment_should_be_able_to_reference_parent_symbols() {
     let parent = Environment::new();
     let child = Environment::from(&parent);
-    let key = "test";
+    let key = identifier_id!("test");
 
     parent.define(&key, obj_bool!(true));
 
@@ -88,7 +90,7 @@ fn child_environment_should_be_able_to_reference_parent_symbols() {
 fn child_environment_should_be_able_to_assign_symbols_to_parents() {
     let parent = Environment::new();
     let child = Environment::from(&parent);
-    let key = "test";
+    let key = identifier_id!("test");
 
     parent.define(&key, obj_bool!(true));
     child.assign(&key, obj_bool!(false));

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -1,5 +1,5 @@
+use crate::ast::expression::Identifier;
 use crate::ast::statement;
-use crate::ast::token;
 use crate::environment::Environment;
 use crate::interpreter;
 use crate::interpreter::Interpreter;
@@ -68,12 +68,12 @@ impl Callable {
 #[derive(Debug, Clone)]
 pub struct Function {
     closure: Rc<Environment>,
-    params: Vec<token::Token>,
+    params: Vec<Identifier>,
     body: statement::Stmt,
 }
 
 impl Function {
-    pub fn new(closure: Rc<Environment>, params: Vec<token::Token>, body: statement::Stmt) -> Self {
+    pub fn new(closure: Rc<Environment>, params: Vec<Identifier>, body: statement::Stmt) -> Self {
         Function {
             closure,
             params,
@@ -88,8 +88,7 @@ impl Function {
     pub fn call(&self, _env: Rc<Environment>, args: Vec<object::Object>) -> CallResult {
         let local = Environment::from(&self.closure);
         for (ident, arg) in self.params.iter().zip(args.into_iter()) {
-            let lexeme = ident.lexeme.clone().unwrap();
-            local.define(&lexeme, arg.clone());
+            local.define(&ident, arg.clone());
         }
 
         let intptr = interpreter::StatefulInterpreter::from(local);

--- a/src/functions/tests/mod.rs
+++ b/src/functions/tests/mod.rs
@@ -30,10 +30,10 @@ fn arity_should_return_the_number_of_params_declared() {
     assert_eq!(0, gen_callable!(gen_func!()).arity());
     assert_eq!(
         1,
-        gen_callable!(gen_func!(vec![tok_identifier!("a"),])).arity()
+        gen_callable!(gen_func!(vec![identifier_id!("a"),])).arity()
     );
     assert_eq!(
         2,
-        gen_callable!(gen_func!(vec![tok_identifier!("a"), tok_identifier!("b")])).arity()
+        gen_callable!(gen_func!(vec![identifier_id!("a"), identifier_id!("b")])).arity()
     );
 }

--- a/src/interpreter/static_methods.rs
+++ b/src/interpreter/static_methods.rs
@@ -7,7 +7,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 pub fn define_statics() -> Rc<Environment> {
     let glbls = Environment::new();
     glbls.define(
-        "clock",
+        &identifier_id!("clock"),
         obj_call!(Box::new(functions::Callable::Static(
             functions::StaticFunc::new(clock)
         ))),

--- a/src/interpreter/tests/expression/call.rs
+++ b/src/interpreter/tests/expression/call.rs
@@ -14,14 +14,15 @@ fn should_return_ok_on_success() {
         Stmt::Block(vec![Stmt::Expression(Expr::Primary(obj_bool!(true)))]),
     );
 
-    interpreter
-        .env
-        .define(&"a", obj_call!(Box::new(functions::Callable::Func(f))));
+    interpreter.env.define(
+        &identifier_id!("a"),
+        obj_call!(Box::new(functions::Callable::Func(f))),
+    );
 
     assert_eq!(
         Ok(None),
         interpreter.interpret(vec![Stmt::Expression(Expr::Call(
-            Box::new(Expr::Variable(tok_identifier!("a"))),
+            Box::new(Expr::Variable(identifier_id!("a"))),
             vec![]
         ))])
     );
@@ -37,16 +38,17 @@ fn should_throw_error_on_arity_mismatch() {
         Stmt::Block(vec![Stmt::Expression(Expr::Primary(obj_bool!(true)))]),
     );
 
-    interpreter
-        .env
-        .define(&"a", obj_call!(Box::new(functions::Callable::Func(f))));
+    interpreter.env.define(
+        &identifier_id!("a"),
+        obj_call!(Box::new(functions::Callable::Func(f))),
+    );
 
     assert_eq!(
         Err(StmtInterpreterErr::Expression(ExprInterpreterErr::CallErr(
             "Arity".to_string()
         ))),
         interpreter.interpret(vec![Stmt::Expression(Expr::Call(
-            Box::new(Expr::Variable(tok_identifier!("a"))),
+            Box::new(Expr::Variable(identifier_id!("a"))),
             vec![Expr::Primary(obj_number!(5.0))]
         ))])
     );

--- a/src/interpreter/tests/expression/variable.rs
+++ b/src/interpreter/tests/expression/variable.rs
@@ -6,14 +6,18 @@ use crate::interpreter::StatefulInterpreter;
 #[test]
 fn declaration_statement_should_set_persistent_global_symbol() {
     let interpreter = StatefulInterpreter::new();
-    interpreter.env.define(&"a", obj_number!(1.0));
-    interpreter.env.define(&"b", obj_number!(2.0));
+    interpreter
+        .env
+        .define(&identifier_id!("a"), obj_number!(1.0));
+    interpreter
+        .env
+        .define(&identifier_id!("b"), obj_number!(2.0));
 
     assert_eq!(
         Ok(None),
         interpreter.interpret(vec![Stmt::Expression(Expr::Addition(AdditionExpr::Add(
-            Box::new(Expr::Variable(tok_identifier!("a"))),
-            Box::new(Expr::Variable(tok_identifier!("b"))),
+            Box::new(Expr::Variable(identifier_id!("a"))),
+            Box::new(Expr::Variable(identifier_id!("b"))),
         )))])
     );
 }

--- a/src/interpreter/tests/statement/mod.rs
+++ b/src/interpreter/tests/statement/mod.rs
@@ -1,6 +1,5 @@
-use crate::ast::expression::Expr;
+use crate::ast::expression::{Expr, Identifier};
 use crate::ast::statement::Stmt;
-use crate::ast::token::{Token, TokenType};
 use crate::functions;
 use crate::interpreter::Interpreter;
 use crate::interpreter::StatefulInterpreter;
@@ -24,12 +23,15 @@ fn print_stmt_should_return_ok() {
 
 #[test]
 fn declaration_statement_should_set_persistent_global_symbol() {
-    let stmt = Stmt::Declaration("test".to_string(), Expr::Primary(obj_bool!(true)));
+    let stmt = Stmt::Declaration(
+        Identifier::Id("test".to_string()),
+        Expr::Primary(obj_bool!(true)),
+    );
     let interpreter = StatefulInterpreter::new();
     interpreter.interpret(vec![stmt]).unwrap();
     assert_eq!(
         Some(obj_bool!(true)),
-        interpreter.env.get(&"test".to_string())
+        interpreter.env.get(&Identifier::Id("test".to_string()))
     );
 }
 
@@ -63,7 +65,7 @@ fn block_statement_with_return_should_return_value() {
 #[test]
 fn function_declaration_statement_should_set_persistent_global_symbol() {
     let block = Stmt::Block(vec![Stmt::Expression(Expr::Primary(obj_bool!(true)))]);
-    let stmt = Stmt::Function("test".to_string(), vec![], Box::new(block));
+    let stmt = Stmt::Function(Identifier::Id("test".to_string()), vec![], Box::new(block));
     let interpreter = StatefulInterpreter::new();
 
     let f = functions::Function::new(
@@ -76,7 +78,7 @@ fn function_declaration_statement_should_set_persistent_global_symbol() {
     interpreter.interpret(vec![stmt]).unwrap();
     assert_eq!(
         Some(expected_call),
-        interpreter.env.get(&"test".to_string())
+        interpreter.env.get(&Identifier::Id("test".to_string()))
     );
 }
 
@@ -84,14 +86,9 @@ fn function_declaration_statement_should_set_persistent_global_symbol() {
 fn function_call_should_return_a_value_when_specified() {
     let block = Stmt::Block(vec![Stmt::Return(Expr::Primary(obj_bool!(true)))]);
     let input = vec![
-        Stmt::Function("test".to_string(), vec![], Box::new(block)),
+        Stmt::Function(Identifier::Id("test".to_string()), vec![], Box::new(block)),
         Stmt::Return(Expr::Call(
-            Box::new(Expr::Variable(Token::new(
-                TokenType::Identifier,
-                1,
-                Some("test".to_string()),
-                None,
-            ))),
+            Box::new(Expr::Variable(Identifier::Id("test".to_string()))),
             vec![],
         )),
     ];
@@ -108,11 +105,11 @@ fn if_statement_should_eval_to_primary_clause_if_condition_is_true() {
     let stmt = Stmt::If(
         Expr::Primary(obj_bool!(true)),
         Box::new(Stmt::Declaration(
-            "test".to_string(),
+            Identifier::Id("test".to_string()),
             Expr::Primary(obj_bool!(true)),
         )),
         Option::Some(Box::new(Stmt::Declaration(
-            "test".to_string(),
+            Identifier::Id("test".to_string()),
             Expr::Primary(obj_bool!(false)),
         ))),
     );
@@ -120,7 +117,7 @@ fn if_statement_should_eval_to_primary_clause_if_condition_is_true() {
     interpreter.interpret(vec![stmt]).unwrap();
     assert_eq!(
         Some(obj_bool!(true)),
-        interpreter.env.get(&"test".to_string())
+        interpreter.env.get(&Identifier::Id("test".to_string()))
     );
 }
 
@@ -130,11 +127,11 @@ fn if_statement_should_eval_to_else_clause_if_condition_is_false() {
     let stmt = Stmt::If(
         Expr::Primary(obj_bool!(false)),
         Box::new(Stmt::Declaration(
-            "test".to_string(),
+            Identifier::Id("test".to_string()),
             Expr::Primary(obj_bool!(true)),
         )),
         Option::Some(Box::new(Stmt::Declaration(
-            "test".to_string(),
+            Identifier::Id("test".to_string()),
             Expr::Primary(obj_bool!(false)),
         ))),
     );
@@ -142,7 +139,7 @@ fn if_statement_should_eval_to_else_clause_if_condition_is_false() {
     interpreter.interpret(vec![stmt]).unwrap();
     assert_eq!(
         Some(obj_bool!(false)),
-        interpreter.env.get(&"test".to_string())
+        interpreter.env.get(&Identifier::Id("test".to_string()))
     );
 }
 
@@ -151,7 +148,7 @@ fn while_statement_should_eval_until_false() {
     let stmt = Stmt::While(
         Expr::Primary(obj_bool!(false)),
         Box::new(Stmt::Declaration(
-            "test".to_string(),
+            Identifier::Id("test".to_string()),
             Expr::Primary(obj_bool!(true)),
         )),
     );

--- a/src/parser/tests/expression_parser.rs
+++ b/src/parser/tests/expression_parser.rs
@@ -3,7 +3,7 @@ use crate::ast::expression::{
     AdditionExpr, ComparisonExpr, EqualityExpr, Expr, LogicalExpr, MultiplicationExpr, UnaryExpr,
 };
 use crate::ast::statement::Stmt;
-use crate::ast::token::{Token, TokenType};
+use crate::ast::token::TokenType;
 use crate::parser::expression_parser::expression;
 use parcel::*;
 
@@ -31,12 +31,7 @@ fn should_parse_assignment_expression() {
         Ok(MatchStatus::Match((
             &input[3..],
             Expr::Assignment(
-                Token::new(
-                    TokenType::Identifier,
-                    1,
-                    Option::Some("test".to_string()),
-                    Option::None
-                ),
+                identifier_id!("test"),
                 Box::new(Expr::Primary(obj_number!(1.0)))
             )
         ))),
@@ -343,10 +338,7 @@ fn should_parse_call_expression_with_single_arg() {
         Ok(MatchStatus::Match((
             &input[4..],
             Expr::Call(
-                Box::new(Expr::Variable(token_from_tt!(
-                    TokenType::Identifier,
-                    "testfunc"
-                ))),
+                Box::new(Expr::Variable(identifier_id!("testfunc"),)),
                 vec![Expr::Primary(obj_bool!(true))]
             )
         ))),
@@ -369,10 +361,7 @@ fn should_parse_call_expression_with_multiple_arg() {
         Ok(MatchStatus::Match((
             &input[6..],
             Expr::Call(
-                Box::new(Expr::Variable(token_from_tt!(
-                    TokenType::Identifier,
-                    "testfunc"
-                ))),
+                Box::new(Expr::Variable(identifier_id!("testfunc"),)),
                 vec![
                     Expr::Primary(obj_bool!(true)),
                     Expr::Primary(obj_bool!(false))
@@ -426,7 +415,7 @@ fn should_parse_lambda_expression_with_parameters() {
         Ok(MatchStatus::Match((
             &input[8..],
             Expr::Lambda(
-                vec![token_from_tt!(TokenType::Identifier, "arg_one")],
+                vec![identifier_id!("arg_one"),],
                 Box::new(Stmt::Block(vec![Stmt::Expression(Expr::Primary(
                     obj_number!(5.0)
                 ))]))

--- a/src/parser/tests/statement_parser.rs
+++ b/src/parser/tests/statement_parser.rs
@@ -33,7 +33,7 @@ fn can_parse_declaration_stmt() {
         Ok(MatchStatus::Match((
             &input[5..],
             vec![Stmt::Declaration(
-                "test".to_string(),
+                identifier_id!("test"),
                 Expr::Primary(obj_number!(5.0))
             )]
         ))),
@@ -59,8 +59,8 @@ fn can_parse_function_declaration_stmt() {
         Ok(MatchStatus::Match((
             &input[9..],
             vec![Stmt::Function(
-                "test".to_string(),
-                vec![token_from_tt!(TokenType::Identifier, "arg_one")],
+                identifier_id!("test"),
+                vec![identifier_id!("arg_one")],
                 Box::new(Stmt::Block(vec![Stmt::Expression(Expr::Primary(
                     obj_number!(5.0)
                 ))]))
@@ -228,27 +228,18 @@ fn can_parse_for_stmt() {
         Ok(MatchStatus::Match((
             &input[20..],
             vec![Stmt::Block(vec![
-                Stmt::Declaration("test".to_string(), Expr::Primary(obj_number!(1.0))),
+                Stmt::Declaration(identifier_id!("test"), Expr::Primary(obj_number!(1.0))),
                 Stmt::While(
                     Expr::Comparison(ComparisonExpr::Less(
-                        Box::new(Expr::Variable(token_from_tt!(
-                            TokenType::Identifier,
-                            "test"
-                        ))),
+                        Box::new(Expr::Variable(identifier_id!("test"))),
                         Box::new(Expr::Primary(obj_number!(5.0)))
                     )),
                     Box::new(Stmt::Block(vec![
-                        Stmt::Print(Expr::Variable(token_from_tt!(
-                            TokenType::Identifier,
-                            "test"
-                        ))),
+                        Stmt::Print(Expr::Variable(identifier_id!("test"))),
                         Stmt::Expression(Expr::Assignment(
-                            token_from_tt!(TokenType::Identifier, "test"),
+                            identifier_id!("test"),
                             Box::new(Expr::Addition(AdditionExpr::Add(
-                                Box::new(Expr::Variable(token_from_tt!(
-                                    TokenType::Identifier,
-                                    "test"
-                                ))),
+                                Box::new(Expr::Variable(identifier_id!("test"))),
                                 Box::new(Expr::Primary(obj_number!(1.0)))
                             )))
                         ))


### PR DESCRIPTION
# Introduction
This PR begins decoupling `Token` types from the AST instead generating an intermediary `Identifier` type to be consumed from within the AST.

# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [ ] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
