### PR TITLE
Implements Hash variant for the Identifer type

### DIFF
--- a/src/ast/expression.rs
+++ b/src/ast/expression.rs
@@ -1,47 +1,7 @@
+use crate::ast::identifier::Identifier;
 use crate::ast::statement;
-use crate::ast::token;
 use crate::object;
-use std::convert;
 use std::fmt;
-
-/// Identifier functions as a replacement for variable names, offering a raw Id and a Hash.
-#[derive(Debug, PartialEq, Eq, Hash, Clone)]
-pub enum Identifier {
-    Hash(String), // todo change this to an actual hash
-    Id(String),
-}
-
-impl fmt::Display for Identifier {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Id(ref s) => write!(f, "{}", s),
-            Self::Hash(ref s) => write!(f, "{}", s),
-        }
-    }
-}
-
-impl convert::TryFrom<token::Token> for Identifier {
-    type Error = &'static str;
-
-    fn try_from(tok: token::Token) -> Result<Identifier, Self::Error> {
-        match tok.lexeme {
-            Some(lexeme) => Ok(Identifier::Id(lexeme)),
-            None => Err("cannot convert token to identifier, lexeme not defined"),
-        }
-    }
-}
-
-impl From<&str> for Identifier {
-    fn from(from: &str) -> Identifier {
-        Identifier::Id(from.to_string())
-    }
-}
-
-impl From<String> for Identifier {
-    fn from(from: String) -> Identifier {
-        Identifier::Id(from)
-    }
-}
 
 /// Represents, and encapsulates one of the four types of expressions possible in
 /// lox currently. Further information can be found on each sub-type.
@@ -332,11 +292,4 @@ impl fmt::Display for UnaryExpr {
             Self::Minus(expr) => write!(f, "(- {})", expr),
         }
     }
-}
-
-#[allow(unused_macros)]
-macro_rules! identifier_id {
-    ($id:expr) => {
-        $crate::ast::expression::Identifier::Id($id.to_string())
-    };
 }

--- a/src/ast/identifier/mod.rs
+++ b/src/ast/identifier/mod.rs
@@ -1,0 +1,70 @@
+use crate::ast::token;
+use std::collections::hash_map::DefaultHasher;
+use std::convert;
+use std::fmt;
+use std::hash::Hasher;
+
+#[cfg(test)]
+mod tests;
+
+/// Identifier functions as a replacement for variable names, offering a raw Id and a Hash.
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub enum Identifier {
+    Hash(u64), // todo change this to an actual hash
+    Id(String),
+}
+
+impl Identifier {
+    /// to_hash will always return a Hash variant. If the type is already a
+    /// Hash, it will return itself. Otherwise the value of the Id variant will
+    /// be hashed and returned via the Hash variant.
+    pub fn to_hash(self) -> Self {
+        match self {
+            s @ Self::Hash(_) => s,
+            Self::Id(id) => {
+                let mut hasher = DefaultHasher::new();
+                hasher.write(&id.into_bytes());
+                Self::Hash(hasher.finish())
+            }
+        }
+    }
+}
+
+impl fmt::Display for Identifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Id(ref s) => write!(f, "{}", s),
+            Self::Hash(ref s) => write!(f, "{}", s),
+        }
+    }
+}
+
+impl convert::TryFrom<token::Token> for Identifier {
+    type Error = &'static str;
+
+    fn try_from(tok: token::Token) -> Result<Identifier, Self::Error> {
+        match (tok.token_type, tok.lexeme) {
+            (token::TokenType::Identifier, Some(lexeme)) => Ok(Identifier::Id(lexeme)),
+            _ => Err("cannot convert token to identifier, lexeme not defined"),
+        }
+    }
+}
+
+impl From<&str> for Identifier {
+    fn from(from: &str) -> Identifier {
+        Identifier::Id(from.to_string())
+    }
+}
+
+impl From<String> for Identifier {
+    fn from(from: String) -> Identifier {
+        Identifier::Id(from)
+    }
+}
+
+#[allow(unused_macros)]
+macro_rules! identifier_id {
+    ($id:expr) => {
+        $crate::ast::identifier::Identifier::Id($id.to_string())
+    };
+}

--- a/src/ast/identifier/mod.rs
+++ b/src/ast/identifier/mod.rs
@@ -30,6 +30,15 @@ impl Identifier {
     }
 }
 
+impl PartialEq<u64> for Identifier {
+    fn eq(&self, other: &u64) -> bool {
+        match self {
+            Self::Hash(h) => *h == *other,
+            _ => false,
+        }
+    }
+}
+
 impl fmt::Display for Identifier {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/src/ast/identifier/tests/mod.rs
+++ b/src/ast/identifier/tests/mod.rs
@@ -1,0 +1,37 @@
+use crate::ast::identifier::Identifier;
+use crate::ast::token;
+use std::convert::TryFrom;
+
+#[test]
+fn should_convert_identfier_token_with_lexeme_to_identfier() {
+    let tok = token::Token::new(
+        token::TokenType::Identifier,
+        0,
+        Some("test".to_string()),
+        None,
+    );
+
+    assert_eq!(
+        Ok(Identifier::Id("test".to_string())),
+        Identifier::try_from(tok)
+    )
+}
+
+#[test]
+fn should_throw_an_error_if_token_not_an_identifer_on_conversion() {
+    let tok = token::Token::new(
+        token::TokenType::LeftParen,
+        0,
+        Some("test".to_string()),
+        None,
+    );
+
+    assert!(Identifier::try_from(tok).is_err())
+}
+
+#[test]
+fn should_throw_an_error_if_token_has_no_lexeme() {
+    let tok = token::Token::new(token::TokenType::Identifier, 0, None, None);
+
+    assert!(Identifier::try_from(tok).is_err())
+}

--- a/src/ast/identifier/tests/mod.rs
+++ b/src/ast/identifier/tests/mod.rs
@@ -35,3 +35,25 @@ fn should_throw_an_error_if_token_has_no_lexeme() {
 
     assert!(Identifier::try_from(tok).is_err())
 }
+
+#[test]
+fn to_hash_returns_itself_if_variant_is_a_hash() {
+    let id = Identifier::Hash(16183295663280961421);
+
+    assert_eq!(Identifier::Hash(16183295663280961421), id.to_hash())
+}
+
+#[test]
+fn to_hash_should_convert_an_id_to_a_matching_value() {
+    let id = Identifier::Id("test".to_string());
+
+    assert_eq!(Identifier::Hash(16183295663280961421), id.to_hash())
+}
+
+#[test]
+fn two_id_identfiers_with_same_value_should_generate_the_same_hash() {
+    let id_one = Identifier::Id("test".to_string());
+    let id_two = Identifier::Id("test".to_string());
+
+    assert_eq!(id_one.to_hash(), id_two.to_hash())
+}

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -2,6 +2,9 @@
 pub mod token;
 
 #[macro_use]
+pub mod identifier;
+
+#[macro_use]
 pub mod expression;
 pub mod statement;
 

--- a/src/ast/statement.rs
+++ b/src/ast/statement.rs
@@ -1,4 +1,5 @@
-use crate::ast::expression::{Expr, Identifier};
+use crate::ast::expression::Expr;
+use crate::ast::identifier::Identifier;
 use std::fmt;
 
 /// Represents, and encapsulates statement types possiblepossible in

--- a/src/environment/mod.rs
+++ b/src/environment/mod.rs
@@ -1,4 +1,4 @@
-use crate::ast::expression::Identifier;
+use crate::ast::identifier::Identifier;
 use crate::object;
 use std::cell::RefCell;
 use std::collections::HashMap;

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -1,4 +1,4 @@
-use crate::ast::expression::Identifier;
+use crate::ast::identifier::Identifier;
 use crate::ast::statement;
 use crate::environment::Environment;
 use crate::interpreter;

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1,7 +1,7 @@
 use crate::ast::expression::{
-    AdditionExpr, ComparisonExpr, EqualityExpr, Expr, Identifier, LogicalExpr, MultiplicationExpr,
-    UnaryExpr,
+    AdditionExpr, ComparisonExpr, EqualityExpr, Expr, LogicalExpr, MultiplicationExpr, UnaryExpr,
 };
+use crate::ast::identifier::Identifier;
 use crate::environment::Environment;
 use crate::functions;
 use crate::object::{Literal, Object};

--- a/src/interpreter/tests/statement/mod.rs
+++ b/src/interpreter/tests/statement/mod.rs
@@ -1,4 +1,5 @@
-use crate::ast::expression::{Expr, Identifier};
+use crate::ast::expression::Expr;
+use crate::ast::identifier::Identifier;
 use crate::ast::statement::Stmt;
 use crate::functions;
 use crate::interpreter::Interpreter;

--- a/src/parser/expression_parser.rs
+++ b/src/parser/expression_parser.rs
@@ -1,5 +1,6 @@
 extern crate parcel;
 use crate::ast::expression::*;
+use crate::ast::identifier::Identifier;
 use crate::ast::token::{Token, TokenType};
 use crate::parser::combinators::{token_type, unzip};
 use crate::parser::statement_parser::block;

--- a/src/parser/statement_parser.rs
+++ b/src/parser/statement_parser.rs
@@ -1,6 +1,7 @@
 extern crate parcel;
 use super::combinators::token_type;
-use crate::ast::expression::{Expr, Identifier};
+use crate::ast::expression::Expr;
+use crate::ast::identifier::Identifier;
 use crate::ast::statement::Stmt;
 use crate::ast::token::{Token, TokenType};
 use crate::parser::expression_parser::expression;


### PR DESCRIPTION
# Introduction
This PR adds a Hash variant and various methods to convert a Hash from an identifier type.

# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [ ] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
