### PR TITLE
Implement scope analysis to prevent issues with shadowing

### DIFF
--- a/examples/shadowing.lox
+++ b/examples/shadowing.lox
@@ -1,0 +1,11 @@
+var a = "global";
+
+{
+  fun showA() {
+    print a;
+  }
+
+  showA();
+  var a = "block";
+  showA();
+}

--- a/src/analyzer/scope/mod.rs
+++ b/src/analyzer/scope/mod.rs
@@ -35,7 +35,20 @@ impl SemanticAnalyzer<Expr, Expr> for ScopeAnalyzer {
     type Error = ScopeAnalyzerErr;
 
     fn analyze(&self, expr: Expr) -> ExprSemanticAnalyzerResult {
-        Ok(expr)
+        match expr {
+            e @ Expr::Grouping(_) => Ok(e),
+            e @ Expr::Lambda(_, _) => Ok(e),
+            e @ Expr::Variable(_) => Ok(e),
+            e @ Expr::Primary(_) => Ok(e),
+            e @ Expr::Call(_, _) => Ok(e),
+            e @ Expr::Unary(_) => Ok(e),
+            e @ Expr::Multiplication(_) => Ok(e),
+            e @ Expr::Addition(_) => Ok(e),
+            e @ Expr::Comparison(_) => Ok(e),
+            e @ Expr::Equality(_) => Ok(e),
+            e @ Expr::Logical(_) => Ok(e),
+            e @ Expr::Assignment(_, _) => Ok(e),
+        }
     }
 }
 
@@ -82,7 +95,16 @@ impl SemanticAnalyzer<Stmt, Stmt> for ScopeAnalyzer {
     type Error = StmtScopeAnalyzerErr;
 
     fn analyze(&self, input: Stmt) -> StmtSemanticAnalyzerResult {
-        Ok(input)
+        match input {
+            s @ Stmt::Expression(_) => Ok(s),
+            s @ Stmt::If(_, _, _) => Ok(s),
+            s @ Stmt::While(_, _) => Ok(s),
+            s @ Stmt::Print(_) => Ok(s),
+            s @ Stmt::Function(_, _, _) => Ok(s),
+            s @ Stmt::Declaration(_, _) => Ok(s),
+            s @ Stmt::Return(_) => Ok(s),
+            s @ Stmt::Block(_) => Ok(s),
+        }
     }
 }
 
@@ -93,3 +115,5 @@ impl SemanticAnalyzer<Box<Stmt>, Stmt> for ScopeAnalyzer {
         self.analyze(*input)
     }
 }
+
+impl ScopeAnalyzer {}

--- a/src/analyzer/scope/mod.rs
+++ b/src/analyzer/scope/mod.rs
@@ -101,13 +101,13 @@ impl SemanticAnalyzer<Stmt, Stmt> for ScopeAnalyzer {
 
     fn analyze(&self, input: Stmt) -> StmtSemanticAnalyzerResult {
         match input {
-            s @ Stmt::Expression(_) => Ok(s),
+            Stmt::Expression(e) => Ok(Stmt::Expression(self.analyze(e)?)),
             s @ Stmt::If(_, _, _) => Ok(s),
-            s @ Stmt::While(_, _) => Ok(s),
-            s @ Stmt::Print(_) => Ok(s),
+            Stmt::While(e, b) => Ok(Stmt::While(self.analyze(e)?, Box::new(self.analyze(b)?))),
+            Stmt::Print(e) => Ok(Stmt::Print(self.analyze(e)?)),
             s @ Stmt::Function(_, _, _) => Ok(s),
             Stmt::Declaration(id, expr) => self.analyze_declaration(id, expr),
-            s @ Stmt::Return(_) => Ok(s),
+            Stmt::Return(e) => Ok(Stmt::Return(self.analyze(e)?)),
             Stmt::Block(stmts) => self.analyze_block(stmts),
         }
     }

--- a/src/analyzer/scope/tests/expression/mod.rs
+++ b/src/analyzer/scope/tests/expression/mod.rs
@@ -34,3 +34,47 @@ fn assignment_expression_should_err_if_variable_is_undeclared() {
 
     assert!(ScopeAnalyzer::new().analyze(input).is_err());
 }
+
+#[test]
+fn variable_analyze_should_resolve_offset() {
+    let sa = ScopeAnalyzer::new();
+    sa.declare_or_assign(identifier_name!("a"));
+
+    let input = Expr::Variable(identifier_name!("a"));
+    let output = Expr::Variable(identifier_id!(0));
+
+    assert_eq!(Ok(output), sa.analyze(input));
+}
+
+#[test]
+fn call_expression_should_match_predefined_value() {
+    let sa = ScopeAnalyzer::new();
+    let input = Expr::Assignment(
+        identifier_name!("test"),
+        Box::new(Expr::Primary(obj_bool!(true))),
+    );
+    let output = Expr::Assignment(identifier_id!(0), Box::new(Expr::Primary(obj_bool!(true))));
+
+    // Pre-declare a test variable for the above assignment to assign to
+    sa.declare_or_assign(identifier_name!("test"));
+
+    assert_eq!(Ok(output), sa.analyze(input));
+}
+
+#[test]
+fn call_analyze_should_resolve_identifiers_to_ids() {
+    let sa = ScopeAnalyzer::new();
+    sa.declare_or_assign(identifier_name!("a"));
+    sa.declare_or_assign(identifier_name!("b"));
+
+    let input = Expr::Call(
+        Box::new(Expr::Variable(identifier_name!("a"))),
+        vec![Expr::Variable(identifier_name!("b"))],
+    );
+    let output = Expr::Call(
+        Box::new(Expr::Variable(identifier_id!(0))),
+        vec![Expr::Variable(identifier_id!(1))],
+    );
+
+    assert_eq!(Ok(output), sa.analyze(input));
+}

--- a/src/analyzer/scope/tests/expression/mod.rs
+++ b/src/analyzer/scope/tests/expression/mod.rs
@@ -1,0 +1,36 @@
+use crate::analyzer::scope::ScopeAnalyzer;
+use crate::analyzer::SemanticAnalyzer;
+use crate::ast::expression::Expr;
+
+#[test]
+fn primary_expression_should_return_ok() {
+    let input = Expr::Primary(obj_bool!(true));
+    let output = input.clone();
+
+    assert_eq!(Ok(output), ScopeAnalyzer::new().analyze(input));
+}
+
+#[test]
+fn assignment_expression_should_match_predefined_value() {
+    let sa = ScopeAnalyzer::new();
+    let input = Expr::Assignment(
+        identifier_name!("test"),
+        Box::new(Expr::Primary(obj_bool!(true))),
+    );
+    let output = Expr::Assignment(identifier_id!(0), Box::new(Expr::Primary(obj_bool!(true))));
+
+    // Pre-declare a test variable for the above assignment to assign to
+    sa.declare_or_assign(identifier_name!("test"));
+
+    assert_eq!(Ok(output), sa.analyze(input));
+}
+
+#[test]
+fn assignment_expression_should_err_if_variable_is_undeclared() {
+    let input = Expr::Assignment(
+        identifier_name!("test"),
+        Box::new(Expr::Primary(obj_bool!(true))),
+    );
+
+    assert!(ScopeAnalyzer::new().analyze(input).is_err());
+}

--- a/src/analyzer/scope/tests/mod.rs
+++ b/src/analyzer/scope/tests/mod.rs
@@ -3,6 +3,8 @@ use crate::analyzer::SemanticAnalyzer;
 use crate::ast::expression::Expr;
 use crate::ast::statement::Stmt;
 
+mod expression;
+
 #[test]
 fn expression_stmt_should_return_ok() {
     let stmts = vec![Stmt::Expression(Expr::Primary(obj_bool!(true)))];

--- a/src/analyzer/scope/tests/mod.rs
+++ b/src/analyzer/scope/tests/mod.rs
@@ -110,7 +110,7 @@ fn function_declaration_statement_should_return_self() {
 
 #[test]
 fn if_statement_should_return_self() {
-    let stmts = vec![Stmt::If(
+    let input = vec![Stmt::If(
         Expr::Primary(obj_bool!(true)),
         Box::new(Stmt::Declaration(
             identifier_name!("test"),
@@ -122,7 +122,19 @@ fn if_statement_should_return_self() {
         ))),
     )];
 
-    assert_eq!(Ok(stmts.clone()), ScopeAnalyzer::new().analyze(stmts));
+    let output = vec![Stmt::If(
+        Expr::Primary(obj_bool!(true)),
+        Box::new(Stmt::Declaration(
+            identifier_id!(0),
+            Expr::Primary(obj_bool!(true)),
+        )),
+        Option::Some(Box::new(Stmt::Declaration(
+            identifier_id!(0),
+            Expr::Primary(obj_bool!(false)),
+        ))),
+    )];
+
+    assert_eq!(Ok(output), ScopeAnalyzer::new().analyze(input));
 }
 
 #[test]

--- a/src/analyzer/scope/tests/mod.rs
+++ b/src/analyzer/scope/tests/mod.rs
@@ -99,13 +99,18 @@ fn block_statement_should_analyze_child_stmts() {
 #[test]
 fn function_declaration_statement_should_return_self() {
     let block = Stmt::Block(vec![Stmt::Expression(Expr::Primary(obj_bool!(true)))]);
-    let stmts = vec![Stmt::Function(
+    let input = vec![Stmt::Function(
         identifier_name!("test"),
         vec![],
-        Box::new(block),
+        Box::new(block.clone()),
+    )];
+    let output = vec![Stmt::Function(
+        identifier_id!(0),
+        vec![],
+        Box::new(block.clone()),
     )];
 
-    assert_eq!(Ok(stmts.clone()), ScopeAnalyzer::new().analyze(stmts));
+    assert_eq!(Ok(output), ScopeAnalyzer::new().analyze(input));
 }
 
 #[test]

--- a/src/analyzer/scope/tests/mod.rs
+++ b/src/analyzer/scope/tests/mod.rs
@@ -18,13 +18,51 @@ fn print_stmt_should_return_self() {
 }
 
 #[test]
-fn declaration_statement_should_return_self() {
-    let stmts = vec![Stmt::Declaration(
-        identifier_id!("test"),
+fn declaration_statement_should_return_id_def() {
+    let input = vec![Stmt::Declaration(
+        identifier_name!("test"),
         Expr::Primary(obj_bool!(true)),
     )];
 
-    assert_eq!(Ok(stmts.clone()), ScopeAnalyzer::new().analyze(stmts));
+    let output = vec![Stmt::Declaration(
+        identifier_id!(0),
+        Expr::Primary(obj_bool!(true)),
+    )];
+
+    assert_eq!(Ok(output), ScopeAnalyzer::new().analyze(input));
+}
+
+#[test]
+fn multiple_unique_declaration_statements_should_increment_id() {
+    let input = vec![
+        Stmt::Declaration(identifier_name!("test"), Expr::Primary(obj_bool!(true))),
+        Stmt::Declaration(
+            identifier_name!("test_again"),
+            Expr::Primary(obj_bool!(false)),
+        ),
+    ];
+
+    let output = vec![
+        Stmt::Declaration(identifier_id!(0), Expr::Primary(obj_bool!(true))),
+        Stmt::Declaration(identifier_id!(1), Expr::Primary(obj_bool!(false))),
+    ];
+
+    assert_eq!(Ok(output), ScopeAnalyzer::new().analyze(input));
+}
+
+#[test]
+fn multiple_matching_declaration_statements_should_increment_id() {
+    let input = vec![
+        Stmt::Declaration(identifier_name!("test"), Expr::Primary(obj_bool!(true))),
+        Stmt::Declaration(identifier_name!("test"), Expr::Primary(obj_bool!(false))),
+    ];
+
+    let output = vec![
+        Stmt::Declaration(identifier_id!(0), Expr::Primary(obj_bool!(true))),
+        Stmt::Declaration(identifier_id!(0), Expr::Primary(obj_bool!(false))),
+    ];
+
+    assert_eq!(Ok(output), ScopeAnalyzer::new().analyze(input));
 }
 
 #[test]
@@ -44,10 +82,25 @@ fn block_statement_should_return_self() {
 }
 
 #[test]
+fn block_statement_should_analyze_child_stmts() {
+    let input = vec![Stmt::Block(vec![Stmt::Declaration(
+        identifier_name!("test"),
+        Expr::Primary(obj_bool!(true)),
+    )])];
+
+    let output = vec![Stmt::Block(vec![Stmt::Declaration(
+        identifier_id!(0),
+        Expr::Primary(obj_bool!(true)),
+    )])];
+
+    assert_eq!(Ok(output), ScopeAnalyzer::new().analyze(input));
+}
+
+#[test]
 fn function_declaration_statement_should_return_self() {
     let block = Stmt::Block(vec![Stmt::Expression(Expr::Primary(obj_bool!(true)))]);
     let stmts = vec![Stmt::Function(
-        identifier_id!("test"),
+        identifier_name!("test"),
         vec![],
         Box::new(block),
     )];
@@ -60,11 +113,11 @@ fn if_statement_should_return_self() {
     let stmts = vec![Stmt::If(
         Expr::Primary(obj_bool!(true)),
         Box::new(Stmt::Declaration(
-            identifier_id!("test"),
+            identifier_name!("test"),
             Expr::Primary(obj_bool!(true)),
         )),
         Option::Some(Box::new(Stmt::Declaration(
-            identifier_id!("test"),
+            identifier_name!("test"),
             Expr::Primary(obj_bool!(false)),
         ))),
     )];
@@ -77,7 +130,7 @@ fn while_statement_should_return_self() {
     let stmts = vec![Stmt::While(
         Expr::Primary(obj_bool!(false)),
         Box::new(Stmt::Declaration(
-            identifier_id!("test"),
+            identifier_name!("test"),
             Expr::Primary(obj_bool!(true)),
         )),
     )];

--- a/src/analyzer/scope/tests/mod.rs
+++ b/src/analyzer/scope/tests/mod.rs
@@ -127,7 +127,7 @@ fn if_statement_should_return_self() {
 
 #[test]
 fn while_statement_should_return_self() {
-    let stmts = vec![Stmt::While(
+    let input = vec![Stmt::While(
         Expr::Primary(obj_bool!(false)),
         Box::new(Stmt::Declaration(
             identifier_name!("test"),
@@ -135,5 +135,13 @@ fn while_statement_should_return_self() {
         )),
     )];
 
-    assert_eq!(Ok(stmts.clone()), ScopeAnalyzer::new().analyze(stmts))
+    let output = vec![Stmt::While(
+        Expr::Primary(obj_bool!(false)),
+        Box::new(Stmt::Declaration(
+            identifier_id!(0),
+            Expr::Primary(obj_bool!(true)),
+        )),
+    )];
+
+    assert_eq!(Ok(output), ScopeAnalyzer::new().analyze(input))
 }

--- a/src/ast/identifier/mod.rs
+++ b/src/ast/identifier/mod.rs
@@ -1,33 +1,16 @@
 use crate::ast::token;
-use std::collections::hash_map::DefaultHasher;
 use std::convert;
 use std::fmt;
-use std::hash::Hasher;
 
 #[cfg(test)]
 mod tests;
 
 /// Identifier functions as a replacement for variable names, offering a raw Id and a Hash.
-#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[derive(Debug, PartialEq, Hash, Eq, Clone)]
 pub enum Identifier {
     Hash(u64), // todo change this to an actual hash
     Name(String),
-}
-
-impl Identifier {
-    /// to_hash will always return a Hash variant. If the type is already a
-    /// Hash, it will return itself. Otherwise the value of the Id variant will
-    /// be hashed and returned via the Hash variant.
-    pub fn to_hash(self) -> Self {
-        match self {
-            s @ Self::Hash(_) => s,
-            Self::Name(name) => {
-                let mut hasher = DefaultHasher::new();
-                hasher.write(&name.into_bytes());
-                Self::Hash(hasher.finish())
-            }
-        }
-    }
+    Id(u64),
 }
 
 impl PartialEq<u64> for Identifier {
@@ -44,6 +27,7 @@ impl fmt::Display for Identifier {
         match self {
             Self::Name(ref s) => write!(f, "{}", s),
             Self::Hash(ref s) => write!(f, "{}", s),
+            Self::Id(ref u) => write!(f, "{}", u),
         }
     }
 }

--- a/src/ast/identifier/mod.rs
+++ b/src/ast/identifier/mod.rs
@@ -11,11 +11,11 @@ mod tests;
 #[derive(Debug, PartialEq, Hash, Eq, Clone)]
 pub enum Identifier {
     Name(String),
-    Id(u64),
+    Id(usize),
 }
 
-impl PartialEq<u64> for Identifier {
-    fn eq(&self, other: &u64) -> bool {
+impl PartialEq<usize> for Identifier {
+    fn eq(&self, other: &usize) -> bool {
         match self {
             Self::Id(h) => *h == *other,
             _ => false,
@@ -56,8 +56,15 @@ impl From<String> for Identifier {
 }
 
 #[allow(unused_macros)]
+macro_rules! identifier_name {
+    ($name:expr) => {
+        $crate::ast::identifier::Identifier::Name($name.to_string())
+    };
+}
+
+#[allow(unused_macros)]
 macro_rules! identifier_id {
     ($id:expr) => {
-        $crate::ast::identifier::Identifier::Name($id.to_string())
+        $crate::ast::identifier::Identifier::Id($id)
     };
 }

--- a/src/ast/identifier/mod.rs
+++ b/src/ast/identifier/mod.rs
@@ -11,7 +11,7 @@ mod tests;
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum Identifier {
     Hash(u64), // todo change this to an actual hash
-    Id(String),
+    Name(String),
 }
 
 impl Identifier {
@@ -21,9 +21,9 @@ impl Identifier {
     pub fn to_hash(self) -> Self {
         match self {
             s @ Self::Hash(_) => s,
-            Self::Id(id) => {
+            Self::Name(name) => {
                 let mut hasher = DefaultHasher::new();
-                hasher.write(&id.into_bytes());
+                hasher.write(&name.into_bytes());
                 Self::Hash(hasher.finish())
             }
         }
@@ -42,7 +42,7 @@ impl PartialEq<u64> for Identifier {
 impl fmt::Display for Identifier {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Id(ref s) => write!(f, "{}", s),
+            Self::Name(ref s) => write!(f, "{}", s),
             Self::Hash(ref s) => write!(f, "{}", s),
         }
     }
@@ -53,7 +53,7 @@ impl convert::TryFrom<token::Token> for Identifier {
 
     fn try_from(tok: token::Token) -> Result<Identifier, Self::Error> {
         match (tok.token_type, tok.lexeme) {
-            (token::TokenType::Identifier, Some(lexeme)) => Ok(Identifier::Id(lexeme)),
+            (token::TokenType::Identifier, Some(lexeme)) => Ok(Identifier::Name(lexeme)),
             _ => Err("cannot convert token to identifier, lexeme not defined"),
         }
     }
@@ -61,19 +61,19 @@ impl convert::TryFrom<token::Token> for Identifier {
 
 impl From<&str> for Identifier {
     fn from(from: &str) -> Identifier {
-        Identifier::Id(from.to_string())
+        Identifier::Name(from.to_string())
     }
 }
 
 impl From<String> for Identifier {
     fn from(from: String) -> Identifier {
-        Identifier::Id(from)
+        Identifier::Name(from)
     }
 }
 
 #[allow(unused_macros)]
 macro_rules! identifier_id {
     ($id:expr) => {
-        $crate::ast::identifier::Identifier::Id($id.to_string())
+        $crate::ast::identifier::Identifier::Name($id.to_string())
     };
 }

--- a/src/ast/identifier/mod.rs
+++ b/src/ast/identifier/mod.rs
@@ -5,10 +5,11 @@ use std::fmt;
 #[cfg(test)]
 mod tests;
 
-/// Identifier functions as a replacement for variable names, offering a raw Id and a Hash.
+/// Identifier functions as a replacement for variable names, offering a raw
+/// name corresponding to a variable name, and an Id functioning as a numeric
+/// reference.
 #[derive(Debug, PartialEq, Hash, Eq, Clone)]
 pub enum Identifier {
-    Hash(u64), // todo change this to an actual hash
     Name(String),
     Id(u64),
 }
@@ -16,7 +17,7 @@ pub enum Identifier {
 impl PartialEq<u64> for Identifier {
     fn eq(&self, other: &u64) -> bool {
         match self {
-            Self::Hash(h) => *h == *other,
+            Self::Id(h) => *h == *other,
             _ => false,
         }
     }
@@ -26,7 +27,6 @@ impl fmt::Display for Identifier {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Name(ref s) => write!(f, "{}", s),
-            Self::Hash(ref s) => write!(f, "{}", s),
             Self::Id(ref u) => write!(f, "{}", u),
         }
     }

--- a/src/ast/identifier/tests/mod.rs
+++ b/src/ast/identifier/tests/mod.rs
@@ -35,25 +35,3 @@ fn should_throw_an_error_if_token_has_no_lexeme() {
 
     assert!(Identifier::try_from(tok).is_err())
 }
-
-#[test]
-fn to_hash_returns_itself_if_variant_is_a_hash() {
-    let id = Identifier::Hash(16183295663280961421);
-
-    assert_eq!(Identifier::Hash(16183295663280961421), id.to_hash())
-}
-
-#[test]
-fn to_hash_should_convert_an_id_to_a_matching_value() {
-    let id = Identifier::Name("test".to_string());
-
-    assert_eq!(Identifier::Hash(16183295663280961421), id.to_hash())
-}
-
-#[test]
-fn two_id_identfiers_with_same_value_should_generate_the_same_hash() {
-    let id_one = Identifier::Name("test".to_string());
-    let id_two = Identifier::Name("test".to_string());
-
-    assert_eq!(id_one.to_hash(), id_two.to_hash())
-}

--- a/src/ast/identifier/tests/mod.rs
+++ b/src/ast/identifier/tests/mod.rs
@@ -12,7 +12,7 @@ fn should_convert_identfier_token_with_lexeme_to_identfier() {
     );
 
     assert_eq!(
-        Ok(Identifier::Id("test".to_string())),
+        Ok(Identifier::Name("test".to_string())),
         Identifier::try_from(tok)
     )
 }
@@ -45,15 +45,15 @@ fn to_hash_returns_itself_if_variant_is_a_hash() {
 
 #[test]
 fn to_hash_should_convert_an_id_to_a_matching_value() {
-    let id = Identifier::Id("test".to_string());
+    let id = Identifier::Name("test".to_string());
 
     assert_eq!(Identifier::Hash(16183295663280961421), id.to_hash())
 }
 
 #[test]
 fn two_id_identfiers_with_same_value_should_generate_the_same_hash() {
-    let id_one = Identifier::Id("test".to_string());
-    let id_two = Identifier::Id("test".to_string());
+    let id_one = Identifier::Name("test".to_string());
+    let id_two = Identifier::Name("test".to_string());
 
     assert_eq!(id_one.to_hash(), id_two.to_hash())
 }

--- a/src/environment/mod.rs
+++ b/src/environment/mod.rs
@@ -30,6 +30,13 @@ impl<K, V> Environment<K, V> {
         })
     }
 
+    pub fn has_key(&self, name: &K) -> bool
+    where
+        K: Eq + Hash + Clone,
+    {
+        self.symbols_table.borrow().contains_key(name)
+    }
+
     pub fn assign(&self, name: &K, value: V) -> Option<V>
     where
         K: Eq + Hash + Clone,

--- a/src/environment/mod.rs
+++ b/src/environment/mod.rs
@@ -1,48 +1,53 @@
-use crate::ast::identifier::Identifier;
-use crate::object;
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::hash::Hash;
 use std::rc::Rc;
 
 #[cfg(test)]
 mod tests;
 
-type SymbolTable = HashMap<Identifier, object::Object>;
-type Parent = Box<Rc<Environment>>;
+type Parent<K, V> = Box<Rc<Environment<K, V>>>;
 
 /// Functions as a symbols table for looking up variables assignments.
 #[derive(Default, Debug)]
-pub struct Environment {
-    parent: Option<Parent>,
-    symbols_table: RefCell<SymbolTable>,
+pub struct Environment<K, V> {
+    parent: Option<Parent<K, V>>,
+    symbols_table: RefCell<HashMap<K, V>>,
 }
 
-impl Environment {
+impl<K, V> Environment<K, V> {
     pub fn new() -> Rc<Self> {
         Rc::new(Environment {
             parent: None,
-            symbols_table: RefCell::new(SymbolTable::new()),
+            symbols_table: RefCell::new(HashMap::new()),
         })
     }
 
-    pub fn from(parent: &Rc<Environment>) -> Rc<Self> {
+    pub fn from(parent: &Rc<Environment<K, V>>) -> Rc<Self> {
         Rc::new(Environment {
             parent: Some(Box::new(parent.clone())),
-            symbols_table: RefCell::new(SymbolTable::new()),
+            symbols_table: RefCell::new(HashMap::new()),
         })
     }
 
-    pub fn assign(&self, name: &Identifier, value: object::Object) -> Option<object::Object> {
-        let id = name;
-        let has_key = self.symbols_table.borrow().contains_key(&id);
+    pub fn assign(&self, name: &K, value: V) -> Option<V>
+    where
+        K: Eq + Hash + Clone,
+        V: Clone,
+    {
+        let has_key = self.symbols_table.borrow().contains_key(name);
         match (has_key, self.parent.as_ref()) {
-            (true, _) => self.define(&id, value),
-            (false, Some(parent)) => parent.assign(&id, value),
+            (true, _) => self.define(name, value),
+            (false, Some(parent)) => parent.assign(name, value),
             (false, None) => None,
         }
     }
 
-    pub fn define(&self, name: &Identifier, value: object::Object) -> Option<object::Object> {
+    pub fn define(&self, name: &K, value: V) -> Option<V>
+    where
+        K: Eq + Hash + Clone,
+        V: Clone,
+    {
         self.symbols_table
             .borrow_mut()
             .insert(name.clone(), value.clone());
@@ -50,11 +55,15 @@ impl Environment {
         Some(value)
     }
 
-    pub fn get(&self, name: &Identifier) -> Option<object::Object> {
+    pub fn get(&self, name: &K) -> Option<V>
+    where
+        K: Eq + Hash + Clone,
+        V: Clone,
+    {
         let val = self.symbols_table.borrow().get(name).cloned();
         match (val, self.parent.as_ref()) {
             (Some(v), _) => Some(v),
-            (None, Some(parent)) => parent.get(&name),
+            (None, Some(parent)) => parent.get(name),
             (None, None) => None,
         }
     }

--- a/src/environment/tests/mod.rs
+++ b/src/environment/tests/mod.rs
@@ -7,7 +7,7 @@ use std::rc::Rc;
 #[test]
 fn environment_should_allow_setting_of_symbols() {
     let symtable: Rc<Environment<Identifier, Object>> = Environment::new();
-    let key = identifier_id!("test");
+    let key = identifier_name!("test");
 
     // unset var returns None
     assert_eq!(
@@ -24,7 +24,7 @@ fn environment_should_allow_setting_of_symbols() {
 #[test]
 fn environment_should_allow_getting_of_symbols() {
     let symtable: Rc<Environment<Identifier, Object>> = Environment::new();
-    let key = identifier_id!("key");
+    let key = identifier_name!("key");
 
     assert_eq!(
         symtable.define(&key, obj_bool!(true)),
@@ -37,7 +37,7 @@ fn environment_should_allow_getting_of_symbols() {
 #[test]
 fn environment_should_return_none_if_assign_of_undefined_symbol() {
     let symtable: Rc<Environment<Identifier, Object>> = Environment::new();
-    let key = identifier_id!("test");
+    let key = identifier_name!("test");
 
     // unset var returns None
     assert_eq!(symtable.assign(&key, obj_bool!(true)), Option::None);
@@ -46,7 +46,7 @@ fn environment_should_return_none_if_assign_of_undefined_symbol() {
 #[test]
 fn environment_should_return_some_if_assign_of_undefined_symbol() {
     let symtable: Rc<Environment<Identifier, Object>> = Environment::new();
-    let key = identifier_id!("test");
+    let key = identifier_name!("test");
 
     symtable.define(&key, obj_bool!(true));
 
@@ -82,7 +82,7 @@ fn new_child_environment_should_have_a_parent() {
 fn child_environment_should_be_able_to_reference_parent_symbols() {
     let parent: Rc<Environment<Identifier, Object>> = Environment::new();
     let child = Environment::from(&parent);
-    let key = identifier_id!("test");
+    let key = identifier_name!("test");
 
     parent.define(&key, obj_bool!(true));
 
@@ -93,7 +93,7 @@ fn child_environment_should_be_able_to_reference_parent_symbols() {
 fn child_environment_should_be_able_to_assign_symbols_to_parents() {
     let parent: Rc<Environment<Identifier, Object>> = Environment::new();
     let child = Environment::from(&parent);
-    let key = identifier_id!("test");
+    let key = identifier_name!("test");
 
     parent.define(&key, obj_bool!(true));
     child.assign(&key, obj_bool!(false));

--- a/src/environment/tests/mod.rs
+++ b/src/environment/tests/mod.rs
@@ -1,9 +1,12 @@
+use crate::ast::identifier::Identifier;
 use crate::environment::Environment;
+use crate::object::Object;
 use std::option::Option;
+use std::rc::Rc;
 
 #[test]
 fn environment_should_allow_setting_of_symbols() {
-    let symtable = Environment::new();
+    let symtable: Rc<Environment<Identifier, Object>> = Environment::new();
     let key = identifier_id!("test");
 
     // unset var returns None
@@ -20,7 +23,7 @@ fn environment_should_allow_setting_of_symbols() {
 
 #[test]
 fn environment_should_allow_getting_of_symbols() {
-    let symtable = Environment::new();
+    let symtable: Rc<Environment<Identifier, Object>> = Environment::new();
     let key = identifier_id!("key");
 
     assert_eq!(
@@ -33,7 +36,7 @@ fn environment_should_allow_getting_of_symbols() {
 
 #[test]
 fn environment_should_return_none_if_assign_of_undefined_symbol() {
-    let symtable = Environment::new();
+    let symtable: Rc<Environment<Identifier, Object>> = Environment::new();
     let key = identifier_id!("test");
 
     // unset var returns None
@@ -42,7 +45,7 @@ fn environment_should_return_none_if_assign_of_undefined_symbol() {
 
 #[test]
 fn environment_should_return_some_if_assign_of_undefined_symbol() {
-    let symtable = Environment::new();
+    let symtable: Rc<Environment<Identifier, Object>> = Environment::new();
     let key = identifier_id!("test");
 
     symtable.define(&key, obj_bool!(true));
@@ -56,7 +59,7 @@ fn environment_should_return_some_if_assign_of_undefined_symbol() {
 
 #[test]
 fn new_environment_should_have_no_parent() {
-    let symtable = Environment::new();
+    let symtable: Rc<Environment<Identifier, Object>> = Environment::new();
 
     match symtable.parent {
         Some(_) => assert!(false),
@@ -66,7 +69,7 @@ fn new_environment_should_have_no_parent() {
 
 #[test]
 fn new_child_environment_should_have_a_parent() {
-    let parent = Environment::new();
+    let parent: Rc<Environment<Identifier, Object>> = Environment::new();
     let child = Environment::from(&parent);
 
     match child.parent {
@@ -77,7 +80,7 @@ fn new_child_environment_should_have_a_parent() {
 
 #[test]
 fn child_environment_should_be_able_to_reference_parent_symbols() {
-    let parent = Environment::new();
+    let parent: Rc<Environment<Identifier, Object>> = Environment::new();
     let child = Environment::from(&parent);
     let key = identifier_id!("test");
 
@@ -88,7 +91,7 @@ fn child_environment_should_be_able_to_reference_parent_symbols() {
 
 #[test]
 fn child_environment_should_be_able_to_assign_symbols_to_parents() {
-    let parent = Environment::new();
+    let parent: Rc<Environment<Identifier, Object>> = Environment::new();
     let child = Environment::from(&parent);
     let key = identifier_id!("test");
 

--- a/src/functions/tests/mod.rs
+++ b/src/functions/tests/mod.rs
@@ -30,10 +30,14 @@ fn arity_should_return_the_number_of_params_declared() {
     assert_eq!(0, gen_callable!(gen_func!()).arity());
     assert_eq!(
         1,
-        gen_callable!(gen_func!(vec![identifier_id!("a"),])).arity()
+        gen_callable!(gen_func!(vec![identifier_name!("a"),])).arity()
     );
     assert_eq!(
         2,
-        gen_callable!(gen_func!(vec![identifier_id!("a"), identifier_id!("b")])).arity()
+        gen_callable!(gen_func!(vec![
+            identifier_name!("a"),
+            identifier_name!("b")
+        ]))
+        .arity()
     );
 }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -73,9 +73,8 @@ impl fmt::Display for ExprInterpreterErr {
 
 pub type ExprInterpreterResult = Result<Object, ExprInterpreterErr>;
 
-#[derive(Default)]
 pub struct StatefulInterpreter {
-    pub env: Rc<Environment>,
+    pub env: Rc<Environment<Identifier, Object>>,
 }
 
 impl StatefulInterpreter {
@@ -88,8 +87,14 @@ impl StatefulInterpreter {
     }
 }
 
-impl From<Rc<Environment>> for StatefulInterpreter {
-    fn from(env: Rc<Environment>) -> StatefulInterpreter {
+impl Default for StatefulInterpreter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl From<Rc<Environment<Identifier, Object>>> for StatefulInterpreter {
+    fn from(env: Rc<Environment<Identifier, Object>>) -> StatefulInterpreter {
         let mut si = StatefulInterpreter::new();
         si.env = env;
         si

--- a/src/interpreter/static_methods.rs
+++ b/src/interpreter/static_methods.rs
@@ -1,10 +1,11 @@
+use crate::ast::identifier::Identifier;
 use crate::environment::Environment;
 use crate::functions;
-use crate::object;
+use crate::object::Object;
 use std::rc::Rc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-pub fn define_statics() -> Rc<Environment> {
+pub fn define_statics() -> Rc<Environment<Identifier, Object>> {
     let glbls = Environment::new();
     glbls.define(
         &identifier_id!("clock"),
@@ -15,7 +16,7 @@ pub fn define_statics() -> Rc<Environment> {
     glbls
 }
 
-fn clock(_env: Rc<Environment>, _args: Vec<object::Object>) -> object::Object {
+fn clock(_env: Rc<Environment<Identifier, Object>>, _args: Vec<Object>) -> Object {
     let t = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()

--- a/src/interpreter/static_methods.rs
+++ b/src/interpreter/static_methods.rs
@@ -8,7 +8,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 pub fn define_statics() -> Rc<Environment<Identifier, Object>> {
     let glbls = Environment::new();
     glbls.define(
-        &identifier_id!("clock"),
+        &identifier_name!("clock"),
         obj_call!(Box::new(functions::Callable::Static(
             functions::StaticFunc::new(clock)
         ))),

--- a/src/interpreter/tests/expression/call.rs
+++ b/src/interpreter/tests/expression/call.rs
@@ -15,14 +15,14 @@ fn should_return_ok_on_success() {
     );
 
     interpreter.env.define(
-        &identifier_id!("a"),
+        &identifier_name!("a"),
         obj_call!(Box::new(functions::Callable::Func(f))),
     );
 
     assert_eq!(
         Ok(None),
         interpreter.interpret(vec![Stmt::Expression(Expr::Call(
-            Box::new(Expr::Variable(identifier_id!("a"))),
+            Box::new(Expr::Variable(identifier_name!("a"))),
             vec![]
         ))])
     );
@@ -39,7 +39,7 @@ fn should_throw_error_on_arity_mismatch() {
     );
 
     interpreter.env.define(
-        &identifier_id!("a"),
+        &identifier_name!("a"),
         obj_call!(Box::new(functions::Callable::Func(f))),
     );
 
@@ -48,7 +48,7 @@ fn should_throw_error_on_arity_mismatch() {
             "Arity".to_string()
         ))),
         interpreter.interpret(vec![Stmt::Expression(Expr::Call(
-            Box::new(Expr::Variable(identifier_id!("a"))),
+            Box::new(Expr::Variable(identifier_name!("a"))),
             vec![Expr::Primary(obj_number!(5.0))]
         ))])
     );

--- a/src/interpreter/tests/expression/variable.rs
+++ b/src/interpreter/tests/expression/variable.rs
@@ -8,16 +8,16 @@ fn declaration_statement_should_set_persistent_global_symbol() {
     let interpreter = StatefulInterpreter::new();
     interpreter
         .env
-        .define(&identifier_id!("a"), obj_number!(1.0));
+        .define(&identifier_name!("a"), obj_number!(1.0));
     interpreter
         .env
-        .define(&identifier_id!("b"), obj_number!(2.0));
+        .define(&identifier_name!("b"), obj_number!(2.0));
 
     assert_eq!(
         Ok(None),
         interpreter.interpret(vec![Stmt::Expression(Expr::Addition(AdditionExpr::Add(
-            Box::new(Expr::Variable(identifier_id!("a"))),
-            Box::new(Expr::Variable(identifier_id!("b"))),
+            Box::new(Expr::Variable(identifier_name!("a"))),
+            Box::new(Expr::Variable(identifier_name!("b"))),
         )))])
     );
 }

--- a/src/interpreter/tests/statement/mod.rs
+++ b/src/interpreter/tests/statement/mod.rs
@@ -25,14 +25,14 @@ fn print_stmt_should_return_ok() {
 #[test]
 fn declaration_statement_should_set_persistent_global_symbol() {
     let stmt = Stmt::Declaration(
-        Identifier::Id("test".to_string()),
+        Identifier::Name("test".to_string()),
         Expr::Primary(obj_bool!(true)),
     );
     let interpreter = StatefulInterpreter::new();
     interpreter.interpret(vec![stmt]).unwrap();
     assert_eq!(
         Some(obj_bool!(true)),
-        interpreter.env.get(&Identifier::Id("test".to_string()))
+        interpreter.env.get(&Identifier::Name("test".to_string()))
     );
 }
 
@@ -66,7 +66,11 @@ fn block_statement_with_return_should_return_value() {
 #[test]
 fn function_declaration_statement_should_set_persistent_global_symbol() {
     let block = Stmt::Block(vec![Stmt::Expression(Expr::Primary(obj_bool!(true)))]);
-    let stmt = Stmt::Function(Identifier::Id("test".to_string()), vec![], Box::new(block));
+    let stmt = Stmt::Function(
+        Identifier::Name("test".to_string()),
+        vec![],
+        Box::new(block),
+    );
     let interpreter = StatefulInterpreter::new();
 
     let f = functions::Function::new(
@@ -79,7 +83,7 @@ fn function_declaration_statement_should_set_persistent_global_symbol() {
     interpreter.interpret(vec![stmt]).unwrap();
     assert_eq!(
         Some(expected_call),
-        interpreter.env.get(&Identifier::Id("test".to_string()))
+        interpreter.env.get(&Identifier::Name("test".to_string()))
     );
 }
 
@@ -87,9 +91,13 @@ fn function_declaration_statement_should_set_persistent_global_symbol() {
 fn function_call_should_return_a_value_when_specified() {
     let block = Stmt::Block(vec![Stmt::Return(Expr::Primary(obj_bool!(true)))]);
     let input = vec![
-        Stmt::Function(Identifier::Id("test".to_string()), vec![], Box::new(block)),
+        Stmt::Function(
+            Identifier::Name("test".to_string()),
+            vec![],
+            Box::new(block),
+        ),
         Stmt::Return(Expr::Call(
-            Box::new(Expr::Variable(Identifier::Id("test".to_string()))),
+            Box::new(Expr::Variable(Identifier::Name("test".to_string()))),
             vec![],
         )),
     ];
@@ -106,11 +114,11 @@ fn if_statement_should_eval_to_primary_clause_if_condition_is_true() {
     let stmt = Stmt::If(
         Expr::Primary(obj_bool!(true)),
         Box::new(Stmt::Declaration(
-            Identifier::Id("test".to_string()),
+            Identifier::Name("test".to_string()),
             Expr::Primary(obj_bool!(true)),
         )),
         Option::Some(Box::new(Stmt::Declaration(
-            Identifier::Id("test".to_string()),
+            Identifier::Name("test".to_string()),
             Expr::Primary(obj_bool!(false)),
         ))),
     );
@@ -118,7 +126,7 @@ fn if_statement_should_eval_to_primary_clause_if_condition_is_true() {
     interpreter.interpret(vec![stmt]).unwrap();
     assert_eq!(
         Some(obj_bool!(true)),
-        interpreter.env.get(&Identifier::Id("test".to_string()))
+        interpreter.env.get(&Identifier::Name("test".to_string()))
     );
 }
 
@@ -128,11 +136,11 @@ fn if_statement_should_eval_to_else_clause_if_condition_is_false() {
     let stmt = Stmt::If(
         Expr::Primary(obj_bool!(false)),
         Box::new(Stmt::Declaration(
-            Identifier::Id("test".to_string()),
+            Identifier::Name("test".to_string()),
             Expr::Primary(obj_bool!(true)),
         )),
         Option::Some(Box::new(Stmt::Declaration(
-            Identifier::Id("test".to_string()),
+            Identifier::Name("test".to_string()),
             Expr::Primary(obj_bool!(false)),
         ))),
     );
@@ -140,7 +148,7 @@ fn if_statement_should_eval_to_else_clause_if_condition_is_false() {
     interpreter.interpret(vec![stmt]).unwrap();
     assert_eq!(
         Some(obj_bool!(false)),
-        interpreter.env.get(&Identifier::Id("test".to_string()))
+        interpreter.env.get(&Identifier::Name("test".to_string()))
     );
 }
 
@@ -149,7 +157,7 @@ fn while_statement_should_eval_until_false() {
     let stmt = Stmt::While(
         Expr::Primary(obj_bool!(false)),
         Box::new(Stmt::Declaration(
-            Identifier::Id("test".to_string()),
+            Identifier::Name("test".to_string()),
             Expr::Primary(obj_bool!(true)),
         )),
     );

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ fn main() {
 
     match args_len {
         al if al > 2 => {
-            println!("Usage: jlox [script]");
+            println!("Usage: rlox [script]");
             process::exit(64);
         }
         2 => run_file(&args[1]).expect("Unable to parse file"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,13 +31,14 @@ fn main() {
 }
 
 fn run_file(filename: &str) -> Result<(), String> {
+    let analyzer = ScopeAnalyzer::new();
     let mut interpreter = StatefulInterpreter::new();
     let mut f = File::open(filename).expect("file not found");
 
     let mut contents = String::new();
     match f.read_to_string(&mut contents) {
         Ok(_) => {
-            run(&mut interpreter, contents).unwrap();
+            run(&analyzer, &mut interpreter, contents).unwrap();
             Ok(())
         }
         Err(error) => Err(format!("error: {}", error)),
@@ -45,6 +46,7 @@ fn run_file(filename: &str) -> Result<(), String> {
 }
 
 fn run_prompt() {
+    let analyzer = ScopeAnalyzer::new();
     let mut interpreter = StatefulInterpreter::new();
     loop {
         let mut input = String::new();
@@ -52,11 +54,15 @@ fn run_prompt() {
         stdout().flush().unwrap();
 
         stdin().read_line(&mut input).expect("execution error");
-        run(&mut interpreter, input).unwrap();
+        run(&analyzer, &mut interpreter, input).unwrap();
     }
 }
 
-fn run(interpreter: &mut StatefulInterpreter, source: String) -> RuntimeResult<usize> {
+fn run(
+    analyzer: &ScopeAnalyzer,
+    interpreter: &mut StatefulInterpreter,
+    source: String,
+) -> RuntimeResult<usize> {
     let token_iter = scanner::Scanner::new(source).scan_tokens().into_iter();
     let token_count = token_iter.len();
 
@@ -80,7 +86,7 @@ fn run(interpreter: &mut StatefulInterpreter, source: String) -> RuntimeResult<u
         }
     }?;
 
-    let analyzed_stmts = ScopeAnalyzer::new().analyze(stmts).unwrap();
+    let analyzed_stmts = analyzer.analyze(stmts).unwrap();
     interpreter
         .interpret(analyzed_stmts)
         .map_err(|e| e.to_string())?;

--- a/src/parser/tests/expression_parser.rs
+++ b/src/parser/tests/expression_parser.rs
@@ -31,7 +31,7 @@ fn should_parse_assignment_expression() {
         Ok(MatchStatus::Match((
             &input[3..],
             Expr::Assignment(
-                identifier_id!("test"),
+                identifier_name!("test"),
                 Box::new(Expr::Primary(obj_number!(1.0)))
             )
         ))),
@@ -338,7 +338,7 @@ fn should_parse_call_expression_with_single_arg() {
         Ok(MatchStatus::Match((
             &input[4..],
             Expr::Call(
-                Box::new(Expr::Variable(identifier_id!("testfunc"),)),
+                Box::new(Expr::Variable(identifier_name!("testfunc"),)),
                 vec![Expr::Primary(obj_bool!(true))]
             )
         ))),
@@ -361,7 +361,7 @@ fn should_parse_call_expression_with_multiple_arg() {
         Ok(MatchStatus::Match((
             &input[6..],
             Expr::Call(
-                Box::new(Expr::Variable(identifier_id!("testfunc"),)),
+                Box::new(Expr::Variable(identifier_name!("testfunc"),)),
                 vec![
                     Expr::Primary(obj_bool!(true)),
                     Expr::Primary(obj_bool!(false))
@@ -415,7 +415,7 @@ fn should_parse_lambda_expression_with_parameters() {
         Ok(MatchStatus::Match((
             &input[8..],
             Expr::Lambda(
-                vec![identifier_id!("arg_one"),],
+                vec![identifier_name!("arg_one"),],
                 Box::new(Stmt::Block(vec![Stmt::Expression(Expr::Primary(
                     obj_number!(5.0)
                 ))]))

--- a/src/parser/tests/statement_parser.rs
+++ b/src/parser/tests/statement_parser.rs
@@ -33,7 +33,7 @@ fn can_parse_declaration_stmt() {
         Ok(MatchStatus::Match((
             &input[5..],
             vec![Stmt::Declaration(
-                identifier_id!("test"),
+                identifier_name!("test"),
                 Expr::Primary(obj_number!(5.0))
             )]
         ))),
@@ -59,8 +59,8 @@ fn can_parse_function_declaration_stmt() {
         Ok(MatchStatus::Match((
             &input[9..],
             vec![Stmt::Function(
-                identifier_id!("test"),
-                vec![identifier_id!("arg_one")],
+                identifier_name!("test"),
+                vec![identifier_name!("arg_one")],
                 Box::new(Stmt::Block(vec![Stmt::Expression(Expr::Primary(
                     obj_number!(5.0)
                 ))]))
@@ -228,18 +228,18 @@ fn can_parse_for_stmt() {
         Ok(MatchStatus::Match((
             &input[20..],
             vec![Stmt::Block(vec![
-                Stmt::Declaration(identifier_id!("test"), Expr::Primary(obj_number!(1.0))),
+                Stmt::Declaration(identifier_name!("test"), Expr::Primary(obj_number!(1.0))),
                 Stmt::While(
                     Expr::Comparison(ComparisonExpr::Less(
-                        Box::new(Expr::Variable(identifier_id!("test"))),
+                        Box::new(Expr::Variable(identifier_name!("test"))),
                         Box::new(Expr::Primary(obj_number!(5.0)))
                     )),
                     Box::new(Stmt::Block(vec![
-                        Stmt::Print(Expr::Variable(identifier_id!("test"))),
+                        Stmt::Print(Expr::Variable(identifier_name!("test"))),
                         Stmt::Expression(Expr::Assignment(
-                            identifier_id!("test"),
+                            identifier_name!("test"),
                             Box::new(Expr::Addition(AdditionExpr::Add(
-                                Box::new(Expr::Variable(identifier_id!("test"))),
+                                Box::new(Expr::Variable(identifier_name!("test"))),
                                 Box::new(Expr::Primary(obj_number!(1.0)))
                             )))
                         ))


### PR DESCRIPTION
# Introduction
This PR adds the ability to walk the tree to resolve variable scope prior to interpreting the AST. This prevents problems with shadowing where scope reference of variables changes between executions. An example of the change in behaviour can be seen through the execution of the example block of code below.

```
var a = "global";

{
  fun showA() {
    print a;
  }

  showA();
  var a = "block";
  showA();
}
```

before:

```
vscode@b5fd59336604:/workspaces/rlox$ cargo run examples/shadowing.lox 
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
     Running `target/debug/rlox examples/shadowing.lox`
global
block
```

after:

```
vscode@b5fd59336604:/workspaces/rlox$ cargo run examples/shadowing.lox 
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
     Running `target/debug/rlox examples/shadowing.lox`
global
global
```

# Linked Issues
resolves #101 
# Dependencies

# Test
- [x] Tested Locally
- [ ] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
