### PR TITLE
Replace Analyzer and Interpreter trait with Pass/PassMut Traits

### DIFF
--- a/src/analyzer/scope/mod.rs
+++ b/src/analyzer/scope/mod.rs
@@ -1,8 +1,8 @@
-use crate::analyzer::SemanticAnalyzerMut;
 use crate::ast::expression::{
     AdditionExpr, ComparisonExpr, EqualityExpr, Expr, LogicalExpr, MultiplicationExpr, UnaryExpr,
 };
 use crate::ast::identifier::Identifier;
+use crate::pass::*;
 use std::fmt;
 
 mod stack;
@@ -46,12 +46,12 @@ impl Default for ScopeAnalyzer {
 
 type ExprSemanticAnalyzerResult = Result<Expr, ScopeAnalyzerErr>;
 
-impl SemanticAnalyzerMut<Expr, Expr> for ScopeAnalyzer {
+impl PassMut<Expr, Expr> for ScopeAnalyzer {
     type Error = ScopeAnalyzerErr;
 
-    fn analyze(&mut self, expr: Expr) -> ExprSemanticAnalyzerResult {
+    fn tree_pass(&mut self, expr: Expr) -> ExprSemanticAnalyzerResult {
         match expr {
-            Expr::Grouping(e) => Ok(Expr::Grouping(Box::new(self.analyze(e)?))),
+            Expr::Grouping(e) => Ok(Expr::Grouping(Box::new(self.tree_pass(e)?))),
             Expr::Lambda(params, body) => self.analyze_lambda(params, *body),
             Expr::Variable(id) => self.analyze_variable(id),
             e @ Expr::Primary(_) => Ok(e),
@@ -73,7 +73,7 @@ impl ScopeAnalyzer {
         id: Identifier,
         expr: Box<Expr>,
     ) -> ExprSemanticAnalyzerResult {
-        let rhv = self.analyze(expr)?;
+        let rhv = self.tree_pass(expr)?;
 
         match self.stack.get_offset(&id) {
             Some(offset) => Ok(Expr::Assignment(Identifier::Id(offset), Box::new(rhv))),
@@ -84,12 +84,12 @@ impl ScopeAnalyzer {
     fn analyze_logical(&mut self, expr: LogicalExpr) -> ExprSemanticAnalyzerResult {
         Ok(Expr::Logical(match expr {
             LogicalExpr::Or(left, right) => LogicalExpr::Or(
-                Box::new(self.analyze(left)?),
-                Box::new(self.analyze(right)?),
+                Box::new(self.tree_pass(left)?),
+                Box::new(self.tree_pass(right)?),
             ),
             LogicalExpr::And(left, right) => LogicalExpr::And(
-                Box::new(self.analyze(left)?),
-                Box::new(self.analyze(right)?),
+                Box::new(self.tree_pass(left)?),
+                Box::new(self.tree_pass(right)?),
             ),
         }))
     }
@@ -97,12 +97,12 @@ impl ScopeAnalyzer {
     fn analyze_equality(&mut self, expr: EqualityExpr) -> ExprSemanticAnalyzerResult {
         Ok(Expr::Equality(match expr {
             EqualityExpr::Equal(left, right) => EqualityExpr::Equal(
-                Box::new(self.analyze(left)?),
-                Box::new(self.analyze(right)?),
+                Box::new(self.tree_pass(left)?),
+                Box::new(self.tree_pass(right)?),
             ),
             EqualityExpr::NotEqual(left, right) => EqualityExpr::NotEqual(
-                Box::new(self.analyze(left)?),
-                Box::new(self.analyze(right)?),
+                Box::new(self.tree_pass(left)?),
+                Box::new(self.tree_pass(right)?),
             ),
         }))
     }
@@ -110,20 +110,20 @@ impl ScopeAnalyzer {
     fn analyze_comparison(&mut self, expr: ComparisonExpr) -> ExprSemanticAnalyzerResult {
         Ok(Expr::Comparison(match expr {
             ComparisonExpr::Greater(left, right) => ComparisonExpr::Greater(
-                Box::new(self.analyze(left)?),
-                Box::new(self.analyze(right)?),
+                Box::new(self.tree_pass(left)?),
+                Box::new(self.tree_pass(right)?),
             ),
             ComparisonExpr::GreaterEqual(left, right) => ComparisonExpr::GreaterEqual(
-                Box::new(self.analyze(left)?),
-                Box::new(self.analyze(right)?),
+                Box::new(self.tree_pass(left)?),
+                Box::new(self.tree_pass(right)?),
             ),
             ComparisonExpr::Less(left, right) => ComparisonExpr::Less(
-                Box::new(self.analyze(left)?),
-                Box::new(self.analyze(right)?),
+                Box::new(self.tree_pass(left)?),
+                Box::new(self.tree_pass(right)?),
             ),
             ComparisonExpr::LessEqual(left, right) => ComparisonExpr::LessEqual(
-                Box::new(self.analyze(left)?),
-                Box::new(self.analyze(right)?),
+                Box::new(self.tree_pass(left)?),
+                Box::new(self.tree_pass(right)?),
             ),
         }))
     }
@@ -131,12 +131,12 @@ impl ScopeAnalyzer {
     fn analyze_addition(&mut self, expr: AdditionExpr) -> ExprSemanticAnalyzerResult {
         Ok(Expr::Addition(match expr {
             AdditionExpr::Add(left, right) => AdditionExpr::Add(
-                Box::new(self.analyze(left)?),
-                Box::new(self.analyze(right)?),
+                Box::new(self.tree_pass(left)?),
+                Box::new(self.tree_pass(right)?),
             ),
             AdditionExpr::Subtract(left, right) => AdditionExpr::Subtract(
-                Box::new(self.analyze(left)?),
-                Box::new(self.analyze(right)?),
+                Box::new(self.tree_pass(left)?),
+                Box::new(self.tree_pass(right)?),
             ),
         }))
     }
@@ -144,29 +144,29 @@ impl ScopeAnalyzer {
     fn analyze_multiplication(&mut self, expr: MultiplicationExpr) -> ExprSemanticAnalyzerResult {
         Ok(Expr::Multiplication(match expr {
             MultiplicationExpr::Multiply(left, right) => MultiplicationExpr::Multiply(
-                Box::new(self.analyze(left)?),
-                Box::new(self.analyze(right)?),
+                Box::new(self.tree_pass(left)?),
+                Box::new(self.tree_pass(right)?),
             ),
             MultiplicationExpr::Divide(left, right) => MultiplicationExpr::Divide(
-                Box::new(self.analyze(left)?),
-                Box::new(self.analyze(right)?),
+                Box::new(self.tree_pass(left)?),
+                Box::new(self.tree_pass(right)?),
             ),
         }))
     }
 
     fn analyze_unary(&mut self, expr: UnaryExpr) -> ExprSemanticAnalyzerResult {
         Ok(Expr::Unary(match expr {
-            UnaryExpr::Bang(expr) => UnaryExpr::Bang(Box::new(self.analyze(expr)?)),
-            UnaryExpr::Minus(expr) => UnaryExpr::Minus(Box::new(self.analyze(expr)?)),
+            UnaryExpr::Bang(expr) => UnaryExpr::Bang(Box::new(self.tree_pass(expr)?)),
+            UnaryExpr::Minus(expr) => UnaryExpr::Minus(Box::new(self.tree_pass(expr)?)),
         }))
     }
 
     fn analyze_call(&mut self, callee: Expr, args: Vec<Expr>) -> ExprSemanticAnalyzerResult {
-        let analyzed_callee = self.analyze(callee)?;
+        let analyzed_callee = self.tree_pass(callee)?;
         let mut analyzed_args: Vec<Expr> = Vec::new();
 
         for arg in args {
-            analyzed_args.push(self.analyze(arg)?);
+            analyzed_args.push(self.tree_pass(arg)?);
         }
 
         Ok(Expr::Call(Box::new(analyzed_callee), analyzed_args))
@@ -184,7 +184,7 @@ impl ScopeAnalyzer {
             .map(|param| self.declare_or_assign(param))
             .collect();
 
-        let analyzed_body = self.analyze(body)?;
+        let analyzed_body = self.tree_pass(body)?;
 
         // exit scope
         self.stack.pop();
@@ -200,10 +200,10 @@ impl ScopeAnalyzer {
     }
 }
 
-impl SemanticAnalyzerMut<Box<Expr>, Expr> for ScopeAnalyzer {
+impl PassMut<Box<Expr>, Expr> for ScopeAnalyzer {
     type Error = ScopeAnalyzerErr;
-    fn analyze(&mut self, expr: Box<Expr>) -> ExprSemanticAnalyzerResult {
-        self.analyze(*expr)
+    fn tree_pass(&mut self, expr: Box<Expr>) -> ExprSemanticAnalyzerResult {
+        self.tree_pass(*expr)
     }
 }
 
@@ -211,36 +211,39 @@ use crate::ast::statement::Stmt;
 
 pub type StmtSemanticAnalyzerResult = Result<Stmt, ScopeAnalyzerErr>;
 
-impl SemanticAnalyzerMut<Vec<Stmt>, Vec<Stmt>> for ScopeAnalyzer {
+impl PassMut<Vec<Stmt>, Vec<Stmt>> for ScopeAnalyzer {
     type Error = ScopeAnalyzerErr;
 
-    fn analyze(&mut self, input: Vec<Stmt>) -> Result<Vec<Stmt>, ScopeAnalyzerErr> {
-        input.into_iter().map(|s| self.analyze(s)).collect()
+    fn tree_pass(&mut self, input: Vec<Stmt>) -> Result<Vec<Stmt>, ScopeAnalyzerErr> {
+        input.into_iter().map(|s| self.tree_pass(s)).collect()
     }
 }
 
-impl SemanticAnalyzerMut<Stmt, Stmt> for ScopeAnalyzer {
+impl PassMut<Stmt, Stmt> for ScopeAnalyzer {
     type Error = ScopeAnalyzerErr;
 
-    fn analyze(&mut self, input: Stmt) -> StmtSemanticAnalyzerResult {
+    fn tree_pass(&mut self, input: Stmt) -> StmtSemanticAnalyzerResult {
         match input {
-            Stmt::Expression(e) => Ok(Stmt::Expression(self.analyze(e)?)),
+            Stmt::Expression(e) => Ok(Stmt::Expression(self.tree_pass(e)?)),
             Stmt::If(cond, tb, eb) => self.analyze_if(cond, tb, eb),
-            Stmt::While(e, b) => Ok(Stmt::While(self.analyze(e)?, Box::new(self.analyze(b)?))),
-            Stmt::Print(e) => Ok(Stmt::Print(self.analyze(e)?)),
+            Stmt::While(e, b) => Ok(Stmt::While(
+                self.tree_pass(e)?,
+                Box::new(self.tree_pass(b)?),
+            )),
+            Stmt::Print(e) => Ok(Stmt::Print(self.tree_pass(e)?)),
             Stmt::Function(name, params, body) => self.analyze_function(name, params, body),
             Stmt::Declaration(id, expr) => self.analyze_declaration(id, expr),
-            Stmt::Return(e) => Ok(Stmt::Return(self.analyze(e)?)),
+            Stmt::Return(e) => Ok(Stmt::Return(self.tree_pass(e)?)),
             Stmt::Block(stmts) => self.analyze_block(stmts),
         }
     }
 }
 
 /// This functions only to unpack an Stmt and dispatch to the upstream SemanticAnalyzer<Stmt, Stmt)> implementation
-impl SemanticAnalyzerMut<Box<Stmt>, Stmt> for ScopeAnalyzer {
+impl PassMut<Box<Stmt>, Stmt> for ScopeAnalyzer {
     type Error = ScopeAnalyzerErr;
-    fn analyze(&mut self, input: Box<Stmt>) -> StmtSemanticAnalyzerResult {
-        self.analyze(*input)
+    fn tree_pass(&mut self, input: Box<Stmt>) -> StmtSemanticAnalyzerResult {
+        self.tree_pass(*input)
     }
 }
 
@@ -268,7 +271,7 @@ impl ScopeAnalyzer {
     fn analyze_block(&mut self, stmts: Vec<Stmt>) -> StmtSemanticAnalyzerResult {
         // enter scope
         self.stack.push(Scope::new());
-        let analyzed_block = self.analyze(stmts)?;
+        let analyzed_block = self.tree_pass(stmts)?;
         // leave scope
         self.stack.pop();
 
@@ -290,7 +293,7 @@ impl ScopeAnalyzer {
             .into_iter()
             .map(|param| self.declare_or_assign(param))
             .collect();
-        let analyzed_body = self.analyze(body)?;
+        let analyzed_body = self.tree_pass(body)?;
         // leave scope
         self.stack.pop();
 
@@ -303,10 +306,10 @@ impl ScopeAnalyzer {
         tb: Box<Stmt>,
         eb: Option<Box<Stmt>>,
     ) -> StmtSemanticAnalyzerResult {
-        let c = self.analyze(cond)?;
-        let then_branch = Box::new(self.analyze(tb)?);
+        let c = self.tree_pass(cond)?;
+        let then_branch = Box::new(self.tree_pass(tb)?);
         let else_branch = match eb {
-            Some(branch) => Some(Box::new(self.analyze(branch)?)),
+            Some(branch) => Some(Box::new(self.tree_pass(branch)?)),
             None => None,
         };
 
@@ -314,7 +317,7 @@ impl ScopeAnalyzer {
     }
 
     fn analyze_declaration(&mut self, id: Identifier, expr: Expr) -> StmtSemanticAnalyzerResult {
-        match self.analyze(expr) {
+        match self.tree_pass(expr) {
             Ok(e) => Ok(Stmt::Declaration(self.declare_or_assign(id), e)),
             Err(e) => Err(e),
         }

--- a/src/analyzer/scope/tests/expression/mod.rs
+++ b/src/analyzer/scope/tests/expression/mod.rs
@@ -1,14 +1,14 @@
 use crate::analyzer::scope::ScopeAnalyzer;
-use crate::analyzer::SemanticAnalyzerMut;
 use crate::ast::expression::Expr;
 use crate::ast::statement::Stmt;
+use crate::pass::*;
 
 #[test]
 fn primary_expression_should_return_ok() {
     let input = Expr::Primary(obj_bool!(true));
     let output = input.clone();
 
-    assert_eq!(Ok(output), ScopeAnalyzer::new().analyze(input));
+    assert_eq!(Ok(output), ScopeAnalyzer::new().tree_pass(input));
 }
 
 #[test]
@@ -23,7 +23,7 @@ fn assignment_expression_should_match_predefined_value() {
     // Pre-declare a test variable for the above assignment to assign to
     sa.declare_or_assign(identifier_name!("test"));
 
-    assert_eq!(Ok(output), sa.analyze(input));
+    assert_eq!(Ok(output), sa.tree_pass(input));
 }
 
 #[test]
@@ -33,7 +33,7 @@ fn assignment_expression_should_err_if_variable_is_undeclared() {
         Box::new(Expr::Primary(obj_bool!(true))),
     );
 
-    assert!(ScopeAnalyzer::new().analyze(input).is_err());
+    assert!(ScopeAnalyzer::new().tree_pass(input).is_err());
 }
 
 #[test]
@@ -44,7 +44,7 @@ fn variable_analyze_should_resolve_offset() {
     let input = Expr::Variable(identifier_name!("a"));
     let output = Expr::Variable(identifier_id!(0));
 
-    assert_eq!(Ok(output), sa.analyze(input));
+    assert_eq!(Ok(output), sa.tree_pass(input));
 }
 
 #[test]
@@ -59,7 +59,7 @@ fn call_expression_should_match_predefined_value() {
     // Pre-declare a test variable for the above assignment to assign to
     sa.declare_or_assign(identifier_name!("test"));
 
-    assert_eq!(Ok(output), sa.analyze(input));
+    assert_eq!(Ok(output), sa.tree_pass(input));
 }
 
 #[test]
@@ -77,7 +77,7 @@ fn call_analyze_should_resolve_identifiers_to_ids() {
         vec![Expr::Variable(identifier_id!(1))],
     );
 
-    assert_eq!(Ok(output), sa.analyze(input));
+    assert_eq!(Ok(output), sa.tree_pass(input));
 }
 
 #[test]
@@ -99,5 +99,5 @@ fn lambda_expression_should_match_predefined_value() {
     // Pre-declare a test variable for the above assignment to assign to
     sa.declare_or_assign(identifier_name!("hello"));
 
-    assert_eq!(Ok(output), sa.analyze(input));
+    assert_eq!(Ok(output), sa.tree_pass(input));
 }

--- a/src/analyzer/scope/tests/statement/mod.rs
+++ b/src/analyzer/scope/tests/statement/mod.rs
@@ -1,20 +1,20 @@
 use crate::analyzer::scope::ScopeAnalyzer;
-use crate::analyzer::SemanticAnalyzerMut;
 use crate::ast::expression::Expr;
 use crate::ast::statement::Stmt;
+use crate::pass::*;
 
 #[test]
 fn expression_stmt_should_return_ok() {
     let stmts = vec![Stmt::Expression(Expr::Primary(obj_bool!(true)))];
 
-    assert_eq!(Ok(stmts.clone()), ScopeAnalyzer::new().analyze(stmts));
+    assert_eq!(Ok(stmts.clone()), ScopeAnalyzer::new().tree_pass(stmts));
 }
 
 #[test]
 fn print_stmt_should_return_self() {
     let stmts = vec![Stmt::Print(Expr::Primary(obj_bool!(true)))];
 
-    assert_eq!(Ok(stmts.clone()), ScopeAnalyzer::new().analyze(stmts));
+    assert_eq!(Ok(stmts.clone()), ScopeAnalyzer::new().tree_pass(stmts));
 }
 
 #[test]
@@ -29,7 +29,7 @@ fn declaration_statement_should_return_id_def() {
         Expr::Primary(obj_bool!(true)),
     )];
 
-    assert_eq!(Ok(output), ScopeAnalyzer::new().analyze(input));
+    assert_eq!(Ok(output), ScopeAnalyzer::new().tree_pass(input));
 }
 
 #[test]
@@ -47,7 +47,7 @@ fn multiple_unique_declaration_statements_should_increment_id() {
         Stmt::Declaration(identifier_id!(1), Expr::Primary(obj_bool!(false))),
     ];
 
-    assert_eq!(Ok(output), ScopeAnalyzer::new().analyze(input));
+    assert_eq!(Ok(output), ScopeAnalyzer::new().tree_pass(input));
 }
 
 #[test]
@@ -62,14 +62,14 @@ fn multiple_matching_declaration_statements_should_increment_id() {
         Stmt::Declaration(identifier_id!(0), Expr::Primary(obj_bool!(false))),
     ];
 
-    assert_eq!(Ok(output), ScopeAnalyzer::new().analyze(input));
+    assert_eq!(Ok(output), ScopeAnalyzer::new().tree_pass(input));
 }
 
 #[test]
 fn return_statement_should_return_self() {
     let stmts = vec![Stmt::Return(Expr::Primary(obj_bool!(true)))];
 
-    assert_eq!(Ok(stmts.clone()), ScopeAnalyzer::new().analyze(stmts));
+    assert_eq!(Ok(stmts.clone()), ScopeAnalyzer::new().tree_pass(stmts));
 }
 
 #[test]
@@ -78,7 +78,7 @@ fn block_statement_should_return_self() {
         obj_bool!(true),
     ))])];
 
-    assert_eq!(Ok(stmts.clone()), ScopeAnalyzer::new().analyze(stmts));
+    assert_eq!(Ok(stmts.clone()), ScopeAnalyzer::new().tree_pass(stmts));
 }
 
 #[test]
@@ -93,7 +93,7 @@ fn block_statement_should_analyze_child_stmts() {
         Expr::Primary(obj_bool!(true)),
     )])];
 
-    assert_eq!(Ok(output), ScopeAnalyzer::new().analyze(input));
+    assert_eq!(Ok(output), ScopeAnalyzer::new().tree_pass(input));
 }
 
 #[test]
@@ -110,7 +110,7 @@ fn function_declaration_statement_should_return_self() {
         Box::new(block.clone()),
     )];
 
-    assert_eq!(Ok(output), ScopeAnalyzer::new().analyze(input));
+    assert_eq!(Ok(output), ScopeAnalyzer::new().tree_pass(input));
 }
 
 #[test]
@@ -139,7 +139,7 @@ fn if_statement_should_return_self() {
         ))),
     )];
 
-    assert_eq!(Ok(output), ScopeAnalyzer::new().analyze(input));
+    assert_eq!(Ok(output), ScopeAnalyzer::new().tree_pass(input));
 }
 
 #[test]
@@ -160,7 +160,7 @@ fn while_statement_should_return_self() {
         )),
     )];
 
-    assert_eq!(Ok(output), ScopeAnalyzer::new().analyze(input))
+    assert_eq!(Ok(output), ScopeAnalyzer::new().tree_pass(input))
 }
 
 #[test]
@@ -221,5 +221,5 @@ fn scope_should_shade_correctly() {
         ]),
     ];
 
-    assert_eq!(Ok(output), ScopeAnalyzer::new().analyze(input))
+    assert_eq!(Ok(output), ScopeAnalyzer::new().tree_pass(input))
 }

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -2,8 +2,8 @@ use crate::ast::identifier::Identifier;
 use crate::ast::statement;
 use crate::environment::Environment;
 use crate::interpreter;
-use crate::interpreter::Interpreter;
 use crate::object::Object;
+use crate::pass::*;
 use std::fmt;
 use std::rc::Rc;
 
@@ -96,7 +96,7 @@ impl Function {
         }
 
         let intptr = interpreter::StatefulInterpreter::from(local);
-        match intptr.interpret(self.body.clone()) {
+        match intptr.tree_pass(self.body.clone()) {
             Ok(rv) => Ok(rv.unwrap_or(obj_nil!())),
             Err(_) => Err(CallError::Unknown),
         }

--- a/src/interpreter/tests/expression/addition.rs
+++ b/src/interpreter/tests/expression/addition.rs
@@ -1,6 +1,6 @@
 use crate::ast::expression::{AdditionExpr, Expr, MultiplicationExpr};
-use crate::interpreter::Interpreter;
 use crate::interpreter::StatefulInterpreter;
+use crate::pass::*;
 
 macro_rules! primary_number {
     ($x:literal) => {
@@ -12,7 +12,7 @@ macro_rules! primary_number {
 
 macro_rules! expr_interpret {
     ($x:expr) => {
-        StatefulInterpreter::new().interpret($x)
+        StatefulInterpreter::new().tree_pass($x)
     };
 }
 

--- a/src/interpreter/tests/expression/call.rs
+++ b/src/interpreter/tests/expression/call.rs
@@ -1,8 +1,8 @@
 use crate::ast::expression::Expr;
 use crate::ast::statement::Stmt;
 use crate::functions;
-use crate::interpreter::Interpreter;
 use crate::interpreter::{ExprInterpreterErr, StatefulInterpreter, StmtInterpreterErr};
+use crate::pass::*;
 
 #[test]
 fn should_return_ok_on_success() {
@@ -21,7 +21,7 @@ fn should_return_ok_on_success() {
 
     assert_eq!(
         Ok(None),
-        interpreter.interpret(vec![Stmt::Expression(Expr::Call(
+        interpreter.tree_pass(vec![Stmt::Expression(Expr::Call(
             Box::new(Expr::Variable(identifier_name!("a"))),
             vec![]
         ))])
@@ -47,7 +47,7 @@ fn should_throw_error_on_arity_mismatch() {
         Err(StmtInterpreterErr::Expression(ExprInterpreterErr::CallErr(
             "Arity".to_string()
         ))),
-        interpreter.interpret(vec![Stmt::Expression(Expr::Call(
+        interpreter.tree_pass(vec![Stmt::Expression(Expr::Call(
             Box::new(Expr::Variable(identifier_name!("a"))),
             vec![Expr::Primary(obj_number!(5.0))]
         ))])

--- a/src/interpreter/tests/expression/comparison.rs
+++ b/src/interpreter/tests/expression/comparison.rs
@@ -1,6 +1,6 @@
 use crate::ast::expression::{ComparisonExpr, Expr, MultiplicationExpr};
-use crate::interpreter::Interpreter;
 use crate::interpreter::StatefulInterpreter;
+use crate::pass::*;
 
 macro_rules! primary_number {
     ($x:literal) => {
@@ -12,7 +12,7 @@ macro_rules! primary_number {
 
 macro_rules! expr_interpret {
     ($x:expr) => {
-        StatefulInterpreter::new().interpret($x)
+        StatefulInterpreter::new().tree_pass($x)
     };
 }
 

--- a/src/interpreter/tests/expression/equality.rs
+++ b/src/interpreter/tests/expression/equality.rs
@@ -1,6 +1,6 @@
 use crate::ast::expression::{EqualityExpr, Expr, MultiplicationExpr};
-use crate::interpreter::Interpreter;
 use crate::interpreter::StatefulInterpreter;
+use crate::pass::*;
 
 macro_rules! primary_number {
     ($x:literal) => {
@@ -20,7 +20,7 @@ macro_rules! primary_string {
 
 macro_rules! expr_interpret {
     ($x:expr) => {
-        StatefulInterpreter::new().interpret($x)
+        StatefulInterpreter::new().tree_pass($x)
     };
 }
 

--- a/src/interpreter/tests/expression/grouping.rs
+++ b/src/interpreter/tests/expression/grouping.rs
@@ -1,6 +1,6 @@
 use crate::ast::expression::{AdditionExpr, Expr, MultiplicationExpr};
-use crate::interpreter::Interpreter;
 use crate::interpreter::StatefulInterpreter;
+use crate::pass::*;
 
 macro_rules! primary_number {
     ($x:literal) => {
@@ -28,7 +28,7 @@ fn grouping_expr_should_interpret_to_equivalent_primary() {
 
     assert_eq!(
         Ok(obj_number!(5.0)),
-        StatefulInterpreter::new().interpret(expr)
+        StatefulInterpreter::new().tree_pass(expr)
     );
 }
 
@@ -44,6 +44,6 @@ fn grouping_expr_should_maintain_operator_precedence() {
 
     assert_eq!(
         Ok(obj_number!(5.0)),
-        StatefulInterpreter::new().interpret(expr)
+        StatefulInterpreter::new().tree_pass(expr)
     );
 }

--- a/src/interpreter/tests/expression/lambda.rs
+++ b/src/interpreter/tests/expression/lambda.rs
@@ -1,7 +1,7 @@
 use crate::ast::expression::Expr;
 use crate::ast::statement::Stmt;
-use crate::interpreter::Interpreter;
 use crate::interpreter::{ExprInterpreterErr, StatefulInterpreter, StmtInterpreterErr};
+use crate::pass::*;
 
 #[test]
 fn should_return_a_value_when_specified() {
@@ -13,7 +13,7 @@ fn should_return_a_value_when_specified() {
 
     assert_eq!(
         Ok(Some(obj_bool!(true))),
-        StatefulInterpreter::new().interpret(input)
+        StatefulInterpreter::new().tree_pass(input)
     );
 }
 
@@ -29,6 +29,6 @@ fn should_throw_error_on_arity_mismatch() {
         Err(StmtInterpreterErr::Expression(ExprInterpreterErr::CallErr(
             "Arity".to_string()
         ))),
-        StatefulInterpreter::new().interpret(input)
+        StatefulInterpreter::new().tree_pass(input)
     );
 }

--- a/src/interpreter/tests/expression/logical.rs
+++ b/src/interpreter/tests/expression/logical.rs
@@ -1,6 +1,6 @@
 use crate::ast::expression::{Expr, LogicalExpr};
-use crate::interpreter::Interpreter;
 use crate::interpreter::StatefulInterpreter;
+use crate::pass::*;
 
 macro_rules! logical_truth_table {
     ($l:literal, "or", $r: literal) => {
@@ -27,7 +27,7 @@ macro_rules! logical_truth_table {
 
 macro_rules! expr_interpret {
     ($x:expr) => {
-        StatefulInterpreter::new().interpret($x)
+        StatefulInterpreter::new().tree_pass($x)
     };
 }
 

--- a/src/interpreter/tests/expression/multiplication.rs
+++ b/src/interpreter/tests/expression/multiplication.rs
@@ -1,7 +1,7 @@
 use crate::ast::expression::{Expr, MultiplicationExpr, UnaryExpr};
 use crate::interpreter::ExprInterpreterErr;
-use crate::interpreter::Interpreter;
 use crate::interpreter::StatefulInterpreter;
+use crate::pass::*;
 
 macro_rules! primary_number {
     ($x:literal) => {
@@ -21,7 +21,7 @@ macro_rules! primary_string {
 
 macro_rules! expr_interpret {
     ($x:expr) => {
-        StatefulInterpreter::new().interpret($x)
+        StatefulInterpreter::new().tree_pass($x)
     };
 }
 

--- a/src/interpreter/tests/expression/primary.rs
+++ b/src/interpreter/tests/expression/primary.rs
@@ -1,6 +1,6 @@
 use crate::ast::expression::Expr;
-use crate::interpreter::Interpreter;
 use crate::interpreter::StatefulInterpreter;
+use crate::pass::*;
 
 #[test]
 fn primary_expr_should_interpret_to_equivalent_primary() {
@@ -8,6 +8,6 @@ fn primary_expr_should_interpret_to_equivalent_primary() {
 
     assert_eq!(
         Ok(obj_number!(5.0)),
-        StatefulInterpreter::new().interpret(expr)
+        StatefulInterpreter::new().tree_pass(expr)
     );
 }

--- a/src/interpreter/tests/expression/unary.rs
+++ b/src/interpreter/tests/expression/unary.rs
@@ -1,6 +1,6 @@
 use crate::ast::expression::{Expr, UnaryExpr};
-use crate::interpreter::Interpreter;
 use crate::interpreter::StatefulInterpreter;
+use crate::pass::*;
 
 #[test]
 fn unary_expr_should_invert_bool_with_bang_operator() {
@@ -9,11 +9,11 @@ fn unary_expr_should_invert_bool_with_bang_operator() {
 
     assert_eq!(
         Ok(obj_bool!(false)),
-        StatefulInterpreter::new().interpret(true_expr)
+        StatefulInterpreter::new().tree_pass(true_expr)
     );
     assert_eq!(
         Ok(obj_bool!(true)),
-        StatefulInterpreter::new().interpret(false_expr)
+        StatefulInterpreter::new().tree_pass(false_expr)
     );
 }
 
@@ -23,6 +23,6 @@ fn unary_expr_should_negate_number_with_minus_operator() {
 
     assert_eq!(
         Ok(obj_number!(-1.0)),
-        StatefulInterpreter::new().interpret(expr)
+        StatefulInterpreter::new().tree_pass(expr)
     );
 }

--- a/src/interpreter/tests/expression/variable.rs
+++ b/src/interpreter/tests/expression/variable.rs
@@ -1,7 +1,7 @@
 use crate::ast::expression::{AdditionExpr, Expr};
 use crate::ast::statement::Stmt;
-use crate::interpreter::Interpreter;
 use crate::interpreter::StatefulInterpreter;
+use crate::pass::*;
 
 #[test]
 fn declaration_statement_should_set_persistent_global_symbol() {
@@ -15,7 +15,7 @@ fn declaration_statement_should_set_persistent_global_symbol() {
 
     assert_eq!(
         Ok(None),
-        interpreter.interpret(vec![Stmt::Expression(Expr::Addition(AdditionExpr::Add(
+        interpreter.tree_pass(vec![Stmt::Expression(Expr::Addition(AdditionExpr::Add(
             Box::new(Expr::Variable(identifier_name!("a"))),
             Box::new(Expr::Variable(identifier_name!("b"))),
         )))])

--- a/src/interpreter/tests/statement/mod.rs
+++ b/src/interpreter/tests/statement/mod.rs
@@ -2,15 +2,15 @@ use crate::ast::expression::Expr;
 use crate::ast::identifier::Identifier;
 use crate::ast::statement::Stmt;
 use crate::functions;
-use crate::interpreter::Interpreter;
 use crate::interpreter::StatefulInterpreter;
+use crate::pass::*;
 
 #[test]
 fn expression_stmt_should_return_ok() {
     assert_eq!(
         Ok(None),
         StatefulInterpreter::new()
-            .interpret(vec![Stmt::Expression(Expr::Primary(obj_bool!(true)))])
+            .tree_pass(vec![Stmt::Expression(Expr::Primary(obj_bool!(true)))])
     );
 }
 
@@ -18,7 +18,7 @@ fn expression_stmt_should_return_ok() {
 fn print_stmt_should_return_ok() {
     assert_eq!(
         Ok(None),
-        StatefulInterpreter::new().interpret(vec![Stmt::Print(Expr::Primary(obj_bool!(true)))])
+        StatefulInterpreter::new().tree_pass(vec![Stmt::Print(Expr::Primary(obj_bool!(true)))])
     );
 }
 
@@ -29,7 +29,7 @@ fn declaration_statement_should_set_persistent_global_symbol() {
         Expr::Primary(obj_bool!(true)),
     );
     let interpreter = StatefulInterpreter::new();
-    interpreter.interpret(vec![stmt]).unwrap();
+    interpreter.tree_pass(vec![stmt]).unwrap();
     assert_eq!(
         Some(obj_bool!(true)),
         interpreter.env.get(&Identifier::Name("test".to_string()))
@@ -41,14 +41,14 @@ fn return_statement_should_return_the_evaluated_expression_value() {
     let stmts = Stmt::Return(Expr::Primary(obj_bool!(true)));
     assert_eq!(
         Ok(Some(obj_bool!(true))),
-        StatefulInterpreter::new().interpret(stmts)
+        StatefulInterpreter::new().tree_pass(stmts)
     );
 }
 
 #[test]
 fn block_statement_should_set_persistent_global_symbol() {
     let stmts = Stmt::Block(vec![Stmt::Expression(Expr::Primary(obj_bool!(true)))]);
-    assert_eq!(Ok(None), StatefulInterpreter::new().interpret(stmts));
+    assert_eq!(Ok(None), StatefulInterpreter::new().tree_pass(stmts));
 }
 
 #[test]
@@ -59,7 +59,7 @@ fn block_statement_with_return_should_return_value() {
     ]);
     assert_eq!(
         Ok(Some(obj_number!(5.0))),
-        StatefulInterpreter::new().interpret(stmts)
+        StatefulInterpreter::new().tree_pass(stmts)
     );
 }
 
@@ -80,7 +80,7 @@ fn function_declaration_statement_should_set_persistent_global_symbol() {
     );
     let expected_call = obj_call!(Box::new(functions::Callable::Func(f)));
 
-    interpreter.interpret(vec![stmt]).unwrap();
+    interpreter.tree_pass(vec![stmt]).unwrap();
     assert_eq!(
         Some(expected_call),
         interpreter.env.get(&Identifier::Name("test".to_string()))
@@ -104,7 +104,7 @@ fn function_call_should_return_a_value_when_specified() {
 
     assert_eq!(
         Ok(Some(obj_bool!(true))),
-        StatefulInterpreter::new().interpret(input)
+        StatefulInterpreter::new().tree_pass(input)
     );
 }
 
@@ -123,7 +123,7 @@ fn if_statement_should_eval_to_primary_clause_if_condition_is_true() {
         ))),
     );
 
-    interpreter.interpret(vec![stmt]).unwrap();
+    interpreter.tree_pass(vec![stmt]).unwrap();
     assert_eq!(
         Some(obj_bool!(true)),
         interpreter.env.get(&Identifier::Name("test".to_string()))
@@ -145,7 +145,7 @@ fn if_statement_should_eval_to_else_clause_if_condition_is_false() {
         ))),
     );
 
-    interpreter.interpret(vec![stmt]).unwrap();
+    interpreter.tree_pass(vec![stmt]).unwrap();
     assert_eq!(
         Some(obj_bool!(false)),
         interpreter.env.get(&Identifier::Name("test".to_string()))
@@ -162,5 +162,5 @@ fn while_statement_should_eval_until_false() {
         )),
     );
 
-    assert_eq!(Ok(None), StatefulInterpreter::new().interpret(vec![stmt]));
+    assert_eq!(Ok(None), StatefulInterpreter::new().tree_pass(vec![stmt]));
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod environment;
 pub mod functions;
 pub mod interpreter;
 pub mod parser;
+pub mod pass;
 pub mod scanner;
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,11 +7,10 @@ use std::process;
 extern crate parcel;
 use parcel::prelude::v1::*;
 use rlox::analyzer::scope::ScopeAnalyzer;
-use rlox::analyzer::SemanticAnalyzerMut;
 use rlox::ast::token;
-use rlox::interpreter::Interpreter;
 use rlox::interpreter::StatefulInterpreter;
 use rlox::parser::statement_parser::statements;
+use rlox::pass::*;
 use rlox::scanner;
 
 type RuntimeResult<T> = Result<T, String>;
@@ -86,9 +85,9 @@ fn run(
         }
     }?;
 
-    let analyzed_stmts = analyzer.analyze(stmts).unwrap();
+    let analyzed_stmts = analyzer.tree_pass(stmts).unwrap();
     interpreter
-        .interpret(analyzed_stmts)
+        .tree_pass(analyzed_stmts)
         .map_err(|e| e.to_string())?;
 
     Ok(token_count)

--- a/src/pass/mod.rs
+++ b/src/pass/mod.rs
@@ -1,0 +1,29 @@
+use std::fmt;
+
+#[cfg(test)]
+mod tests;
+
+#[derive(PartialEq, Debug)]
+pub enum PassErr {
+    TypeErr(String),
+}
+
+impl fmt::Display for PassErr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::TypeErr(e) => write!(f, "invalid type: {}", e),
+        }
+    }
+}
+
+pub trait Pass<A, B> {
+    type Error;
+
+    fn tree_pass(&self, input: A) -> Result<B, Self::Error>;
+}
+
+pub trait PassMut<A, B> {
+    type Error;
+
+    fn tree_pass(&mut self, input: A) -> Result<B, Self::Error>;
+}


### PR DESCRIPTION
# Introduction
This PR unifies the `Analyzer` and `Interpreter` traits into a single pass trait.

# Linked Issues
#108 

# Dependencies

# Test
- [x] Tested Locally
- [ ] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
