### PR TITLE
Bugfix/globals no longer work in analyzer

### DIFF
--- a/examples/fib-statics.lox
+++ b/examples/fib-statics.lox
@@ -1,0 +1,9 @@
+fun fib(n) {
+  if (n < 2) return n;
+  return fib(n - 1) + fib(n - 2); 
+}
+
+var before = clock();
+print fib(40);
+var after = clock();
+print after - before;

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -6,10 +6,9 @@ use crate::environment::Environment;
 use crate::functions;
 use crate::object::{Literal, Object};
 use crate::pass::*;
+use crate::statics;
 use std::fmt;
 use std::rc::Rc;
-
-mod static_methods;
 
 #[cfg(test)]
 mod tests;
@@ -74,7 +73,7 @@ pub struct StatefulInterpreter {
 
 impl StatefulInterpreter {
     pub fn new() -> StatefulInterpreter {
-        let glbls = static_methods::define_statics();
+        let glbls = statics::define_statics();
 
         StatefulInterpreter {
             env: Environment::from(&glbls),

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -6,7 +6,6 @@ use crate::environment::Environment;
 use crate::functions;
 use crate::object::{Literal, Object};
 use crate::pass::*;
-use crate::statics;
 use std::fmt;
 use std::rc::Rc;
 
@@ -73,10 +72,8 @@ pub struct StatefulInterpreter {
 
 impl StatefulInterpreter {
     pub fn new() -> StatefulInterpreter {
-        let glbls = statics::define_statics();
-
         StatefulInterpreter {
-            env: Environment::from(&glbls),
+            env: Environment::new(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod interpreter;
 pub mod parser;
 pub mod pass;
 pub mod scanner;
+pub mod statics;
 
 #[cfg(test)]
 mod tests;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,11 +7,13 @@ use std::process;
 extern crate parcel;
 use parcel::prelude::v1::*;
 use rlox::analyzer::scope::ScopeAnalyzer;
+use rlox::ast::statement::Stmt;
 use rlox::ast::token;
 use rlox::interpreter::StatefulInterpreter;
 use rlox::parser::statement_parser::statements;
 use rlox::pass::*;
 use rlox::scanner;
+use rlox::statics;
 
 type RuntimeResult<T> = Result<T, String>;
 
@@ -85,10 +87,18 @@ fn run(
         }
     }?;
 
-    let analyzed_stmts = analyzer.tree_pass(stmts).unwrap();
+    let ast = load_statics(stmts);
+    let analyzed_stmts = analyzer.tree_pass(ast).unwrap();
     interpreter
         .tree_pass(analyzed_stmts)
         .map_err(|e| e.to_string())?;
 
     Ok(token_count)
+}
+
+fn load_statics(ast: Vec<Stmt>) -> Vec<Stmt> {
+    let mut ast = ast;
+    let mut ast_with_statics = statics::define_statics_ast();
+    ast_with_statics.append(&mut ast);
+    ast_with_statics
 }

--- a/src/statics/mod.rs
+++ b/src/statics/mod.rs
@@ -7,17 +7,6 @@ use crate::object::Object;
 use std::rc::Rc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-pub fn define_statics() -> Rc<Environment<Identifier, Object>> {
-    let glbls = Environment::new();
-    glbls.define(
-        &identifier_name!("clock"),
-        obj_call!(Box::new(functions::Callable::Static(
-            functions::StaticFunc::new(clock)
-        ))),
-    );
-    glbls
-}
-
 pub fn define_statics_ast() -> Vec<Stmt> {
     vec![Stmt::Declaration(
         identifier_name!("clock"),

--- a/src/statics/mod.rs
+++ b/src/statics/mod.rs
@@ -1,4 +1,6 @@
+use crate::ast::expression::Expr;
 use crate::ast::identifier::Identifier;
+use crate::ast::statement::Stmt;
 use crate::environment::Environment;
 use crate::functions;
 use crate::object::Object;
@@ -14,6 +16,15 @@ pub fn define_statics() -> Rc<Environment<Identifier, Object>> {
         ))),
     );
     glbls
+}
+
+pub fn define_statics_ast() -> Vec<Stmt> {
+    vec![Stmt::Declaration(
+        identifier_name!("clock"),
+        Expr::Primary(obj_call!(Box::new(functions::Callable::Static(
+            functions::StaticFunc::new(clock)
+        )))),
+    )]
 }
 
 fn clock(_env: Rc<Environment<Identifier, Object>>, _args: Vec<Object>) -> Object {


### PR DESCRIPTION
# Introduction
This PR implements a globals loader that moves static methods outside of the concept of the interpreter, instead choosing to add them directly to the AST as a load method.

# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [ ] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
